### PR TITLE
Removing use of `BaseObject` constructor

### DIFF
--- a/src/DataReader.php
+++ b/src/DataReader.php
@@ -68,7 +68,6 @@ class DataReader extends \yii\base\BaseObject implements \Iterator, \Countable
     {
         $this->_statement = $command->pdoStatement;
         $this->_statement->setFetchMode(\PDO::FETCH_ASSOC);
-        parent::__construct($config);
     }
 
     /**

--- a/src/Expression.php
+++ b/src/Expression.php
@@ -52,7 +52,6 @@ class Expression extends \yii\base\BaseObject implements ExpressionInterface
     {
         $this->expression = $expression;
         $this->params = $params;
-        parent::__construct($config);
     }
 
     /**

--- a/src/SqlTokenizer.php
+++ b/src/SqlTokenizer.php
@@ -74,7 +74,6 @@ abstract class SqlTokenizer extends Component
     public function __construct($sql, $config = [])
     {
         $this->sql = $sql;
-        parent::__construct($config);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | no
