### PR TITLE
Fix missing query constructor

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -1301,6 +1301,27 @@ PATTERN;
     }
 
     /**
+     * Constructor for query object
+     */
+    public function __construct($config = [])
+    {
+        $this->where = isset($config['where'])?$config['where']:null;
+        $this->limit = isset($config['limit'])?$config['limit']:null;
+        $this->offset = isset($config['offset'])?$config['offset']:null;
+        $this->orderBy = isset($config['orderBy'])?$config['orderBy']:null;
+        $this->indexBy = isset($config['indexBy'])?$config['indexBy']:null;
+        $this->select = isset($config['select'])?$config['select']:null;
+        $this->selectOption = isset($config['selectOption'])?$config['selectOption']:null;
+        $this->distinct = isset($config['distinct'])?$config['distinct']:null;
+        $this->from = isset($config['from'])?$config['from']:null;
+        $this->groupBy = isset($config['groupBy'])?$config['groupBy']:null;
+        $this->join = isset($config['join'])?$config['join']:null;
+        $this->having = isset($config['having'])?$config['having']:null;
+        $this->union = isset($config['union'])?$config['union']:null;
+        $this->params = isset($config['params'])?$config['params']:null;
+    }
+
+    /**
      * Returns the SQL representation of Query
      * @return string
      */

--- a/src/Query.php
+++ b/src/Query.php
@@ -1305,20 +1305,9 @@ PATTERN;
      */
     public function __construct($config = [])
     {
-        $this->where = isset($config['where'])?$config['where']:null;
-        $this->limit = isset($config['limit'])?$config['limit']:null;
-        $this->offset = isset($config['offset'])?$config['offset']:null;
-        $this->orderBy = isset($config['orderBy'])?$config['orderBy']:null;
-        $this->indexBy = isset($config['indexBy'])?$config['indexBy']:null;
-        $this->select = isset($config['select'])?$config['select']:null;
-        $this->selectOption = isset($config['selectOption'])?$config['selectOption']:null;
-        $this->distinct = isset($config['distinct'])?$config['distinct']:null;
-        $this->from = isset($config['from'])?$config['from']:null;
-        $this->groupBy = isset($config['groupBy'])?$config['groupBy']:null;
-        $this->join = isset($config['join'])?$config['join']:null;
-        $this->having = isset($config['having'])?$config['having']:null;
-        $this->union = isset($config['union'])?$config['union']:null;
-        $this->params = isset($config['params'])?$config['params']:null;
+        if (!empty($config)) {
+            \yii\di\AbstractContainer::configure($this, $config);
+        }
     }
 
     /**

--- a/tests/unit/CommandTest.php
+++ b/tests/unit/CommandTest.php
@@ -7,9 +7,9 @@
 
 namespace yii\db\tests\unit;
 
-use yii\caching\ArrayCache;
-use yii\caching\Cache;
-use yii\caching\FileCache;
+use yii\cache\ArrayCache;
+use yii\cache\Cache;
+use yii\cache\FileCache;
 use yii\db\Connection;
 use yii\db\DataReader;
 use yii\db\Exception;

--- a/tests/unit/DatabaseTestCase.php
+++ b/tests/unit/DatabaseTestCase.php
@@ -7,7 +7,7 @@
 
 namespace yii\db\tests\unit;
 
-use yii\caching\DummyCache;
+use yii\cache\DummyCache;
 use yii\db\Connection;
 use yii\tests\TestCase;
 

--- a/tests/unit/QueryTest.php
+++ b/tests/unit/QueryTest.php
@@ -7,8 +7,8 @@
 
 namespace yii\db\tests\unit;
 
-use yii\caching\ArrayCache;
-use yii\caching\Cache;
+use yii\cache\ArrayCache;
+use yii\cache\Cache;
 use yii\db\Connection;
 use yii\db\Expression;
 use yii\db\Query;

--- a/tests/unit/SchemaTest.php
+++ b/tests/unit/SchemaTest.php
@@ -8,8 +8,8 @@
 namespace yii\db\tests\unit;
 
 use PDO;
-use yii\caching\ArrayCache;
-use yii\caching\FileCache;
+use yii\cache\ArrayCache;
+use yii\cache\FileCache;
 use yii\db\CheckConstraint;
 use yii\db\ColumnSchema;
 use yii\db\Constraint;


### PR DESCRIPTION
Fix missing yii\db\Query object that cause no table use error in tests.