### PR TITLE
Improve schema classes.

### DIFF
--- a/src/Connection/Connection.php
+++ b/src/Connection/Connection.php
@@ -187,9 +187,9 @@ class Connection
      * supported by Yii.
      */
     private array $schemaMap = [
-        'pgsql' => \Yiisoft\Db\Pgsql\Schema::class, // PostgreSQL
-        'mysqli' => \Yiisoft\Db\Mysql\Schema::class, // MySQL
-        'mysql' => \Yiisoft\Db\Mysql\Schema::class, // MySQL
+        'pgsql' => \Yiisoft\Db\Pgsql\Schema\Schema::class, // PostgreSQL
+        'mysqli' => \Yiisoft\Db\Mysql\Schema\Schema::class, // MySQL
+        'mysql' => \Yiisoft\Db\Mysql\Schema\Schema::class, // MySQL
         'sqlite' => \Yiisoft\Db\Sqlite\Schema\Schema::class, // sqlite 3
         'sqlite2' => \Yiisoft\Db\Sqlite\Schema\Schema::class, // sqlite 2
         'sqlsrv' => \Yiisoft\Db\Mssql\Schema::class, // newer MSSQL driver on MS Windows hosts

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -355,7 +355,7 @@ class QueryBuilder
     {
         $schema = $this->db->getSchema();
         $tableSchema = $schema->getTableSchema($table);
-        $columnSchemas = $tableSchema !== null ? $tableSchema->columns : [];
+        $columnSchemas = $tableSchema !== null ? $tableSchema->getColumns() : [];
         $names = [];
         $placeholders = [];
         $values = ' DEFAULT VALUES';
@@ -453,7 +453,7 @@ class QueryBuilder
         $schema = $this->db->getSchema();
 
         if (($tableSchema = $schema->getTableSchema($table)) !== null) {
-            $columnSchemas = $tableSchema->columns;
+            $columnSchemas = $tableSchema->getColumns();
         } else {
             $columnSchemas = [];
         }
@@ -695,7 +695,7 @@ class QueryBuilder
     {
         $tableSchema = $this->db->getTableSchema($table);
 
-        $columnSchemas = $tableSchema !== null ? $tableSchema->columns : [];
+        $columnSchemas = $tableSchema !== null ? $tableSchema->getColumns() : [];
 
         $sets = [];
 

--- a/src/Schema/ColumnSchemaBuilder.php
+++ b/src/Schema/ColumnSchemaBuilder.php
@@ -21,72 +21,22 @@ class ColumnSchemaBuilder
      * {@see $categoryMap} for mappings of abstract column types to category.
      */
     public const CATEGORY_PK = 'pk';
-
     public const CATEGORY_STRING = 'string';
-
     public const CATEGORY_NUMERIC = 'numeric';
-
     public const CATEGORY_TIME = 'time';
-
     public const CATEGORY_OTHER = 'other';
 
-    /**
-     * @var string the column type definition such as INTEGER, VARCHAR, DATETIME, etc.
-     */
-    protected string $type;
-
-    /**
-     * @var int|string|array column size or precision definition. This is what goes into the parenthesis after the
-     * column type. This can be either a string, an integer or an array. If it is an array, the array values will be
-     * joined into a string separated by comma.
-     */
-    protected $length;
-
-    /**
-     * @var bool|null whether the column is or not nullable. If this is `true`, a `NOT NULL` constraint will be added.
-     * If this is `false`, a `NULL` constraint will be added.
-     */
-    protected ?bool $isNotNull = null;
-
-    /**
-     * @var bool whether the column values should be unique. If this is `true`, a `UNIQUE` constraint will be added.
-     */
-    protected bool $isUnique = false;
-
-    /**
-     * @var string the `CHECK` constraint for the column.
-     */
-    protected ?string $check = null;
-
-    /**
-     * @var mixed default value of the column.
-     */
-    protected $default;
-
-    /**
-     * @var mixed SQL string to be appended to column schema definition.
-     */
-    protected $append;
-
-    /**
-     * @var bool whether the column values should be unsigned. If this is `true`, an `UNSIGNED` keyword will be added.
-     */
-    protected bool $isUnsigned = false;
-
-    /**
-     * @var string the column after which this column will be added.
-     */
-    protected ?string $after = null;
-
-    /**
-     * @var bool whether this column is to be inserted at the beginning of the table.
-     */
-    protected bool $isFirst = false;
-
-    /**
-     * @var array mapping of abstract column types (keys) to type categories (values).
-     */
-    public array $categoryMap = [
+    private ?string $type = null;
+    private $length;
+    private ?bool $isNotNull = null;
+    private bool $isUnique = false;
+    private ?string $check = null;
+    private $default;
+    private $append;
+    private bool $isUnsigned = false;
+    private ?string $after = null;
+    private bool $isFirst = false;
+    private array $categoryMap = [
         Schema::TYPE_PK        => self::CATEGORY_PK,
         Schema::TYPE_UPK       => self::CATEGORY_PK,
         Schema::TYPE_BIGPK     => self::CATEGORY_PK,
@@ -109,25 +59,9 @@ class ColumnSchemaBuilder
         Schema::TYPE_BOOLEAN   => self::CATEGORY_NUMERIC,
         Schema::TYPE_MONEY     => self::CATEGORY_NUMERIC,
     ];
+    private ?Connection $db;
+    private ?string $comment = null;
 
-    /**
-     * @var Connection|null the current database connection. It is used mainly to escape strings safely
-     * when building the final column schema string.
-     */
-    protected ?Connection $db;
-
-    /**
-     * @var string comment value of the column.
-     */
-    protected ?string $comment = null;
-
-    /**
-     * Create a column schema builder instance giving the type and value precision.
-     *
-     * @param string $type type of the column. See {@see $type}.
-     * @param int|string|array $length length or precision of the column. See {@see $length}.
-     * @param Connection|null $db the current database connection. See {@see $db}.
-     */
     public function __construct(string $type, $length = null, ?Connection $db = null)
     {
         $this->type = $type;
@@ -491,5 +425,114 @@ class ColumnSchemaBuilder
         ];
 
         return strtr($format, $placeholderValues);
+    }
+
+    /**
+     * @return string|null the column type definition such as INTEGER, VARCHAR, DATETIME, etc.
+     */
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return int|string|array column size or precision definition. This is what goes into the parenthesis after the
+     * column type. This can be either a string, an integer or an array. If it is an array, the array values will be
+     * joined into a string separated by comma.
+     */
+    public function getLength()
+    {
+        return $this->length;
+    }
+
+    /**
+     * @return bool|null whether the column is or not nullable. If this is `true`, a `NOT NULL` constraint will be
+     * added. If this is `false`, a `NULL` constraint will be added.
+     */
+    public function getIsNotNull(): ?bool
+    {
+        return $this->isNotNull;
+    }
+
+    /**
+     * @return bool whether the column values should be unique. If this is `true`, a `UNIQUE` constraint will be added.
+     */
+    public function getIsUnique(): bool
+    {
+        return $this->isUnique;
+    }
+
+    /**
+     * @return string|null the `CHECK` constraint for the column.
+     */
+    public function getCheck(): ?string
+    {
+        return $this->check;
+    }
+
+    /**
+     * @return mixed default value of the column.
+     */
+    public function getDefault()
+    {
+        return $this->default;
+    }
+
+    /**
+     * @return mixed SQL string to be appended to column schema definition.
+     */
+    public function getAppend()
+    {
+        return $this->append;
+    }
+
+    /**
+     * @return bool whether the column values should be unsigned. If this is `true`, an `UNSIGNED` keyword will be
+     * added.
+     */
+    public function getIsUnsigned(): bool
+    {
+        return $this->isUnsigned;
+    }
+
+    /**
+     * @return string|null the column after which this column will be added.
+     */
+    public function getAfter(): ?string
+    {
+        return $this->after;
+    }
+
+    /**
+     * @return bool whether this column is to be inserted at the beginning of the table.
+     */
+    public function getIsFirst(): bool
+    {
+        return $this->isFirst;
+    }
+
+    /**
+     * @return array mapping of abstract column types (keys) to type categories (values).
+     */
+    public function getCategoryMap(): array
+    {
+        return $this->categoryMap;
+    }
+
+    /**
+     * @return Connection|null the current database connection. It is used mainly to escape strings safely
+     * when building the final column schema string.
+     */
+    public function getDb(): ?Connection
+    {
+        return $this->db;
+    }
+
+    /**
+     * @return string comment value of the column.
+     */
+    public function getComment(): ?string
+    {
+        return $this->comment;
     }
 }

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -21,133 +21,78 @@ use Yiisoft\Cache\Dependency\TagDependency;
  * @property string $lastInsertID The row ID of the last row inserted, or the last value retrieved from the sequence
  * object. This property is read-only.
  * @property QueryBuilder $queryBuilder The query builder for this connection. This property is read-only.
- * @property string[] $schemaNames All schema names in the database, except system schemas. This property is
- * read-only.
+ * @property string[] $schemaNames All schema names in the database, except system schemas. This property is read-only.
  * @property string $serverVersion Server version as a string. This property is read-only.
  * @property string[] $tableNames All table names in the database. This property is read-only.
- * @property TableSchema[] $tableSchemas The metadata for all tables in the database. Each array element is an
- * instance of {@see TableSchema} or its child class. This property is read-only.
- * @property string $transactionIsolationLevel The transaction isolation level to use for this transaction.
- * This can be one of {@see Transaction::READ_UNCOMMITTED}, {@see Transaction::READ_COMMITTED},
+ * @property TableSchema[] $tableSchemas The metadata for all tables in the database. Each array element is an instance
+ * of {@see TableSchema} or its child class. This property is read-only.
+ * @property string $transactionIsolationLevel The transaction isolation level to use for this transaction. This can be
+ * one of {@see Transaction::READ_UNCOMMITTED}, {@see Transaction::READ_COMMITTED},
  * {@see Transaction::REPEATABLE_READ} and {@see Transaction::SERIALIZABLE} but also a string containing DBMS specific
  * syntax to be used after `SET TRANSACTION ISOLATION LEVEL`. This property is write-only.
  */
 abstract class Schema
 {
-    /* The following are the supported abstract column data types. */
     public const TYPE_PK = 'pk';
-
     public const TYPE_UPK = 'upk';
-
     public const TYPE_BIGPK = 'bigpk';
-
     public const TYPE_UBIGPK = 'ubigpk';
-
     public const TYPE_CHAR = 'char';
-
     public const TYPE_STRING = 'string';
-
     public const TYPE_TEXT = 'text';
-
     public const TYPE_TINYINT = 'tinyint';
-
     public const TYPE_SMALLINT = 'smallint';
-
     public const TYPE_INTEGER = 'integer';
-
     public const TYPE_BIGINT = 'bigint';
-
     public const TYPE_FLOAT = 'float';
-
     public const TYPE_DOUBLE = 'double';
-
     public const TYPE_DECIMAL = 'decimal';
-
     public const TYPE_DATETIME = 'datetime';
-
     public const TYPE_TIMESTAMP = 'timestamp';
-
     public const TYPE_TIME = 'time';
-
     public const TYPE_DATE = 'date';
-
     public const TYPE_BINARY = 'binary';
-
     public const TYPE_BOOLEAN = 'boolean';
-
     public const TYPE_MONEY = 'money';
-
     public const TYPE_JSON = 'json';
 
     /**
-     * Schema cache version, to detect incompatibilities in cached values when the
-     * data format of the cache changes.
+     * Schema cache version, to detect incompatibilities in cached values when the data format of the cache changes.
      */
-    public const SCHEMA_CACHE_VERSION = 1;
-
-    /**
-     * @var Connection the database connection
-     */
-    public ?Connection $db = null;
+    protected const SCHEMA_CACHE_VERSION = 1;
 
     /**
      * @var string|null the default schema name used for the current session.
      */
-    public ?string $defaultSchema = null;
+    protected ?string $defaultSchema = null;
 
     /**
      * @var array map of DB errors and corresponding exceptions. If left part is found in DB error message exception
      * class from the right part is used.
      */
-    public array $exceptionMap = [
+    protected array $exceptionMap = [
         'SQLSTATE[23' => IntegrityException::class,
     ];
-
-    /**
-     * @var string|array column schema class or class config
-     */
-    public string $columnSchemaClass = ColumnSchema::class;
 
     /**
      * @var string|string[] character used to quote schema, table, etc. names. An array of 2 characters can be used in
      * case starting and ending characters are different.
      */
     protected string $tableQuoteCharacter = "'";
+
     /**
      * @var string|string[] character used to quote column names. An array of 2 characters can be used in case starting
      * and ending characters are different.
      */
     protected string $columnQuoteCharacter = '"';
 
-    /**
-     * @var array list of ALL schema names in the database, except system schemas
-     */
     private array $schemaNames = [];
-
-    /**
-     * @var array list of ALL table names in the database
-     */
     private array $tableNames = [];
-
-    /**
-     * @var array list of loaded table metadata (table name => metadata type => metadata).
-     */
     private array $tableMetadata = [];
-
-    /**
-     * @var QueryBuilder the query builder for this database
-     */
     private ?QueryBuilder $builder = null;
-
-    /**
-     * @var string server version as a string.
-     */
     private ?string $serverVersion = null;
-
-    /**
-     * @var CacheInterface $cache
-     */
     private CacheInterface $cache;
+    private ?Connection $db = null;
 
     public function __construct(Connection $db)
     {
@@ -158,7 +103,7 @@ abstract class Schema
     /**
      * Resolves the table name and schema name (if any).
      *
-     * @param string $name the table name
+     * @param string $name the table name.
      *
      * @return void with resolved table, schema, etc. names.
      *
@@ -206,7 +151,7 @@ abstract class Schema
     /**
      * Loads the metadata for the specified table.
      *
-     * @param string $name table name
+     * @param string $name table name.
      *
      * @return TableSchema|null DBMS-dependent table metadata, `null` if the table does not exist.
      */
@@ -221,7 +166,7 @@ abstract class Schema
      */
     protected function createColumnSchema(): ColumnSchema
     {
-        return new $this->columnSchemaClass();
+        return new ColumnSchema();
     }
 
     /**
@@ -245,8 +190,8 @@ abstract class Schema
      * @param bool $refresh whether to fetch the latest available table schemas. If this is `false`, cached data may be
      * returned if available.
      *
-     * @return TableSchema[] the metadata for all tables in the database.
-     *                       Each array element is an instance of [[TableSchema]] or its child class.
+     * @return TableSchema[] the metadata for all tables in the database. Each array element is an instance of
+     * {@see TableSchema} or its child class.
      */
     public function getTableSchemas(string $schema = '', bool $refresh = false): array
     {
@@ -309,7 +254,7 @@ abstract class Schema
      *
      * @return int the PDO type
      *
-     * @see http://www.php.net/manual/en/pdo.constants.php
+     * {@see http://www.php.net/manual/en/pdo.constants.php}
      */
     public function getPdoType($data): int
     {
@@ -371,7 +316,7 @@ abstract class Schema
      *
      * This method may be overridden by child classes to create a DBMS-specific query builder.
      *
-     * @return QueryBuilder query builder instance
+     * @return QueryBuilder query builder instance.
      */
     public function createQueryBuilder()
     {
@@ -405,8 +350,8 @@ abstract class Schema
      * ]
      * ```
      *
-     * This method should be overridden by child classes in order to support this feature
-     * because the default implementation simply throws an exception
+     * This method should be overridden by child classes in order to support this feature because the default
+     * implementation simply throws an exception
      *
      * @param TableSchema $table the table metadata
      *
@@ -488,7 +433,7 @@ abstract class Schema
      * {@see Transaction::REPEATABLE_READ} and {@see Transaction::SERIALIZABLE} but also a string containing DBMS
      * specific syntax to be used after `SET TRANSACTION ISOLATION LEVEL`.
      *
-     * @see http://en.wikipedia.org/wiki/Isolation_%28database_systems%29#Isolation_levels
+     * {@see http://en.wikipedia.org/wiki/Isolation_%28database_systems%29#Isolation_levels}
      */
     public function setTransactionIsolationLevel(string $level): void
     {
@@ -498,10 +443,10 @@ abstract class Schema
     /**
      * Executes the INSERT command, returning primary key values.
      *
-     * @param string $table   the table that new rows will be inserted into.
-     * @param array  $columns the column data (name => value) to be inserted into the table.
+     * @param string $table the table that new rows will be inserted into.
+     * @param array $columns the column data (name => value) to be inserted into the table.
      *
-     * @return array|false primary key values or false if the command fails
+     * @return array|false primary key values or false if the command fails.
      */
     public function insert(string $table, array $columns)
     {
@@ -528,13 +473,14 @@ abstract class Schema
 
     /**
      * Quotes a string value for use in a query.
+     *
      * Note that if the parameter is not a string, it will be returned without change.
      *
-     * @param string|int $str string to be quoted
+     * @param string|int $str string to be quoted.
      *
-     * @return string|int the properly quoted string
+     * @return string|int the properly quoted string.
      *
-     * @see http://www.php.net/manual/en/function.PDO-quote.php
+     * {@see http://www.php.net/manual/en/function.PDO-quote.php}
      */
     public function quoteValue($str)
     {
@@ -546,7 +492,7 @@ abstract class Schema
             return $value;
         }
 
-        // the driver doesn't support quote (e.g. oci)
+        /** the driver doesn't support quote (e.g. oci) */
         return "'" . addcslashes(str_replace("'", "''", $str), "\000\n\r\\\032") . "'";
     }
 
@@ -556,11 +502,11 @@ abstract class Schema
      * If the table name contains schema prefix, the prefix will also be properly quoted. If the table name is already
      * quoted or contains '(' or '{{', then this method will do nothing.
      *
-     * @param string $name table name
+     * @param string $name table name.
      *
-     * @return string the properly quoted table name
+     * @return string the properly quoted table name.
      *
-     * @see quoteSimpleTableName()
+     * {@see quoteSimpleTableName()}
      */
     public function quoteTableName(string $name): string
     {
@@ -587,11 +533,11 @@ abstract class Schema
      * If the column name contains prefix, the prefix will also be properly quoted. If the column name is already quoted
      * or contains '(', '[[' or '{{', then this method will do nothing.
      *
-     * @param string $name column name
+     * @param string $name column name.
      *
-     * @return string the properly quoted column name
+     * @return string the properly quoted column name.
      *
-     * @see quoteSimpleColumnName()
+     * {@see quoteSimpleColumnName()}
      */
     public function quoteColumnName(string $name): string
     {
@@ -616,12 +562,12 @@ abstract class Schema
     /**
      * Quotes a simple table name for use in a query.
      *
-     * A simple table name should contain the table name only without any schema prefix.
-     * If the table name is already quoted, this method will do nothing.
+     * A simple table name should contain the table name only without any schema prefix. If the table name is already
+     * quoted, this method will do nothing.
      *
-     * @param string $name table name
+     * @param string $name table name.
      *
-     * @return string the properly quoted table name
+     * @return string the properly quoted table name.
      */
     public function quoteSimpleTableName(string $name): string
     {
@@ -637,12 +583,12 @@ abstract class Schema
     /**
      * Quotes a simple column name for use in a query.
      *
-     * A simple column name should contain the column name only without any prefix.
-     * If the column name is already quoted or is the asterisk character '*', this method will do nothing.
+     * A simple column name should contain the column name only without any prefix. If the column name is already quoted
+     * or is the asterisk character '*', this method will do nothing.
      *
-     * @param string $name column name
+     * @param string $name column name.
      *
-     * @return string the properly quoted column name
+     * @return string the properly quoted column name.
      */
     public function quoteSimpleColumnName(string $name): string
     {
@@ -659,8 +605,8 @@ abstract class Schema
     /**
      * Unquotes a simple table name.
      *
-     * A simple table name should contain the table name only without any schema prefix.
-     * If the table name is not quoted, this method will do nothing.
+     * A simple table name should contain the table name only without any schema prefix. If the table name is not
+     * quoted, this method will do nothing.
      *
      * @param string $name table name.
      *
@@ -680,8 +626,8 @@ abstract class Schema
     /**
      * Unquotes a simple column name.
      *
-     * A simple column name should contain the column name only without any prefix.
-     * If the column name is not quoted or is the asterisk character '*', this method will do nothing.
+     * A simple column name should contain the column name only without any prefix. If the column name is not quoted or
+     * is the asterisk character '*', this method will do nothing.
      *
      * @param string $name column name.
      *
@@ -701,12 +647,12 @@ abstract class Schema
     /**
      * Returns the actual name of a given table name.
      *
-     * This method will strip off curly brackets from the given table name
-     * and replace the percentage character '%' with {@see Connection::tablePrefix}.
+     * This method will strip off curly brackets from the given table name and replace the percentage character '%' with
+     * {@see Connection::tablePrefix}.
      *
-     * @param string $name the table name to be converted
+     * @param string $name the table name to be converted.
      *
-     * @return string the real name of the given table name
+     * @return string the real name of the given table name.
      */
     public function getRawTableName(string $name): string
     {
@@ -722,9 +668,9 @@ abstract class Schema
     /**
      * Extracts the PHP type from abstract DB type.
      *
-     * @param ColumnSchema $column the column schema information
+     * @param ColumnSchema $column the column schema information.
      *
-     * @return string PHP type name
+     * @return string PHP type name.
      */
     protected function getColumnPhpType(ColumnSchema $column): string
     {
@@ -760,7 +706,7 @@ abstract class Schema
      * Converts a DB exception to a more concrete one if possible.
      *
      * @param \Exception $e
-     * @param string $rawSql SQL that produced exception
+     * @param string $rawSql SQL that produced exception.
      *
      * @return Exception
      */
@@ -787,7 +733,7 @@ abstract class Schema
     /**
      * Returns a value indicating whether a SQL statement is for read purpose.
      *
-     * @param string $sql the SQL statement
+     * @param string $sql the SQL statement.
      *
      * @return bool whether a SQL statement is for read purpose.
      */
@@ -831,9 +777,10 @@ abstract class Schema
 
     /**
      * Returns the cache tag name.
+     *
      * This allows {@see refresh()} to invalidate all cached table schemas.
      *
-     * @return string the cache tag name
+     * @return string the cache tag name.
      */
     protected function getCacheTag(): string
     {
@@ -847,12 +794,12 @@ abstract class Schema
     /**
      * Returns the metadata of the given type for the given table.
      *
-     * If there's no metadata in the cache, this method will call
-     * a `'loadTable' . ucfirst($type)` named method with the table name to obtain the metadata.
+     * If there's no metadata in the cache, this method will call a `'loadTable' . ucfirst($type)` named method with the
+     * table name to obtain the metadata.
      *
      * @param string $name table name. The table name may contain schema name if any. Do not quote the table name.
      * @param string $type metadata type.
-     * @param bool   $refresh whether to reload the table metadata even if it is found in the cache.
+     * @param bool $refresh whether to reload the table metadata even if it is found in the cache.
      *
      * @return mixed metadata.
      */
@@ -878,8 +825,9 @@ abstract class Schema
 
     /**
      * Returns the metadata of the given type for all tables in the given schema.
-     * This method will call a `'getTable' . ucfirst($type)` named method with the table name
-     * and the refresh flag to obtain the metadata.
+     *
+     * This method will call a `'getTable' . ucfirst($type)` named method with the table name and the refresh flag to
+     * obtain the metadata.
      *
      * @param string $schema the schema of the metadata. Defaults to empty string, meaning the current or default schema
      * name.
@@ -923,7 +871,7 @@ abstract class Schema
      * Changes row's array key case to lower if PDO's one is set to uppercase.
      *
      * @param array $row row's array or an array of row's arrays.
-     * @param bool  $multiple whether multiple rows or a single row passed.
+     * @param bool $multiple whether multiple rows or a single row passed.
      *
      * @return array normalized row or rows.
      */
@@ -990,5 +938,10 @@ abstract class Schema
             $this->db->getSchemaCacheDuration(),
             new TagDependency(['tags' => $this->getCacheTag()])
         );
+    }
+
+    public function getDb(): ?Connection
+    {
+        return $this->db;
     }
 }

--- a/src/Schema/TableSchema.php
+++ b/src/Schema/TableSchema.php
@@ -11,54 +11,14 @@ use Yiisoft\Db\Exception\InvalidArgumentException;
  *
  * @property array $columnNames List of column names. This property is read-only.
  */
-class TableSchema
+abstract class TableSchema
 {
-    /**
-     * @var string|null the name of the schema that this table belongs to.
-     */
-    public ?string $schemaName = null;
-
-    /**
-     * @var string the name of this table. The schema name is not included. Use {@see fullName} to get the name with
-     * schema name prefix.
-     */
-    public string $name;
-
-    /**
-     * @var string the full name of this table, which includes the schema name prefix, if any.
-     * Note that if the schema name is the same as the {@see Schema::defaultSchema|default schema name}, the schema name
-     * will not be included.
-     */
-    public string $fullName;
-
-    /**
-     * @var array primary keys of this table.
-     */
-    public array $primaryKey = [];
-
-    /**
-     * @var string sequence name for the primary key. Null if no sequence.
-     */
-    public ?string $sequenceName = null;
-
-    /**
-     * @var array foreign keys of this table. Each array element is of the following structure:
-     *
-     * ```php
-     * [
-     *  'ForeignTableName',
-     *  'fk1' => 'pk1',  // pk1 is in foreign table
-     *  'fk2' => 'pk2',  // if composite foreign key
-     * ]
-     * ```
-     */
-    public array $foreignKeys = [];
-
-    /**
-     * @var ColumnSchema[] column metadata of this table. Each array element is a {@see ColumnSchema} object, indexed by
-     * column names.
-     */
-    public array $columns = [];
+    private ?string $schemaName = null;
+    private ?string $name = null;
+    private ?string $fullName = null;
+    private ?string $sequenceName = null;
+    private array $primaryKey = [];
+    private array $columns = [];
 
     /**
      * Gets the named column metadata.
@@ -69,7 +29,7 @@ class TableSchema
      *
      * @return ColumnSchema metadata of the named column. Null if the named column does not exist.
      */
-    public function getColumn($name): ColumnSchema
+    public function getColumn(?string $name): ColumnSchema
     {
         return $this->columns[$name] ?? null;
     }
@@ -107,5 +67,87 @@ class TableSchema
                 throw new InvalidArgumentException("Primary key '$key' cannot be found in table '{$this->name}'.");
             }
         }
+    }
+
+    /**
+     * @return string|null the name of the schema that this table belongs to.
+     */
+    public function getSchemaName(): ?string
+    {
+        return $this->schemaName;
+    }
+
+    /**
+     * @return string|null the name of this table. The schema name is not included. Use {@see fullName} to get the name
+     * with schema name prefix.
+     */
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return string|null the full name of this table, which includes the schema name prefix, if any. Note that if the
+     * schema name is the same as the {@see Schema::defaultSchema|default schema name}, the schema name will not be
+     * included.
+     */
+    public function getFullName(): ?string
+    {
+        return $this->fullName;
+    }
+
+    /**
+     * @return string|null sequence name for the primary key. Null if no sequence.
+     */
+    public function getSequenceName(): ?string
+    {
+        return $this->sequenceName;
+    }
+
+    /**
+     * @return array primary keys of this table.
+     */
+    public function getPrimaryKey(): array
+    {
+        return $this->primaryKey;
+    }
+
+    /**
+     * @return ColumnSchema[] column metadata of this table. Each array element is a {@see ColumnSchema} object, indexed
+     * by column names.
+     */
+    public function getColumns(): array
+    {
+        return $this->columns;
+    }
+
+    public function schemaName(?string $value): void
+    {
+        $this->schemaName = $value;
+    }
+
+    public function name(?string $value): void
+    {
+        $this->name = $value;
+    }
+
+    public function fullName(?string $value): void
+    {
+        $this->fullName = $value;
+    }
+
+    public function sequenceName(?string $value): void
+    {
+        $this->sequenceName = $value;
+    }
+
+    public function primaryKey(string $value): void
+    {
+        $this->primaryKey[] = $value;
+    }
+
+    public function columns(string $index, ColumnSchema $value): void
+    {
+        $this->columns[$index] = $value;
     }
 }

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -1623,11 +1623,11 @@ SQL;
         if ($this->driverName !== 'sqlite') {
             $db->createCommand()->addForeignKey($fkName, $tableName, 'fk', $tableName, 'id')->execute();
 
-            $this->assertNotEmpty($db->getSchema()->getTableSchema($tableName)->foreignKeys);
+            $this->assertNotEmpty($db->getSchema()->getTableSchema($tableName)->getForeignKeys());
 
             $db->createCommand()->dropForeignKey($fkName, $tableName)->execute();
 
-            $this->assertEmpty($db->getSchema()->getTableSchema($tableName)->foreignKeys);
+            $this->assertEmpty($db->getSchema()->getTableSchema($tableName)->getForeignKeys());
 
             $db->createCommand()->addCommentOnColumn($tableName, 'id', 'Test comment')->execute();
 

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Yiisoft\Db\Tests;
 
 use Yiisoft\Db\Connection\Connection;
-use Yiisoft\Db\Mysql\QueryBuilder as MysqlQueryBuilder;
-use Yiisoft\Db\Pgsql\QueryBuilder as PgsqlQueryBuilder;
 use Yiisoft\Db\Query\Query;
 use Yiisoft\Db\Query\QueryBuilder;
 use Yiisoft\Db\Query\Conditions\BetweenColumnsCondition;
+use Yiisoft\Db\Mysql\Query\QueryBuilder as MysqlQueryBuilder;
+use Yiisoft\Db\Pgsql\Query\QueryBuilder as PgsqlQueryBuilder;
 use Yiisoft\Db\Sqlite\Query\QueryBuilder as SqliteQueryBuilder;
 use Yiisoft\Db\Schema\Schema;
 use Yiisoft\Db\Schema\SchemaBuilderTrait;

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -121,8 +121,8 @@ abstract class SchemaTest extends DatabaseTestCase
         /* @var $schema Schema */
         $schema = $db->getSchema();
 
-        $schema->db->setEnableSchemaCache(true);
-        $schema->db->setSchemaCache($this->cache);
+        $schema->getDb()->setEnableSchemaCache(true);
+        $schema->getDb()->setSchemaCache($this->cache);
 
         $noCacheTable = $schema->getTableSchema('type', true);
         $cachedTable = $schema->getTableSchema('type', false);
@@ -146,8 +146,8 @@ abstract class SchemaTest extends DatabaseTestCase
         /* @var $schema Schema */
         $schema = $this->getConnection()->getSchema();
 
-        $schema->db->setEnableSchemaCache(true);
-        $schema->db->setSchemaCache($this->cache);
+        $schema->getDb()->setEnableSchemaCache(true);
+        $schema->getDb()->setSchemaCache($this->cache);
 
         $noCacheTable = $schema->getTableSchema('type', true);
         $schema->refreshTableSchema('type');
@@ -207,20 +207,20 @@ abstract class SchemaTest extends DatabaseTestCase
         /* @var $schema Schema */
         $schema = $this->getConnection()->getSchema();
 
-        $schema->db->setEnableSchemaCache(true);
-        $schema->db->setSchemaCache($this->cache);
-        $schema->db->setTablePrefix($tablePrefix);
+        $schema->getDb()->setEnableSchemaCache(true);
+        $schema->getDb()->setSchemaCache($this->cache);
+        $schema->getDb()->setTablePrefix($tablePrefix);
         $noCacheTable = $schema->getTableSchema($tableName, true);
 
         $this->assertInstanceOf(TableSchema::class, $noCacheTable);
 
         // Compare
-        $schema->db->setTablePrefix($testTablePrefix);
+        $schema->getDb()->setTablePrefix($testTablePrefix);
         $testNoCacheTable = $schema->getTableSchema($testTableName);
 
         $this->assertSame($noCacheTable, $testNoCacheTable);
 
-        $schema->db->setTablePrefix($tablePrefix);
+        $schema->getDb()->setTablePrefix($tablePrefix);
         $schema->refreshTableSchema($tableName);
         $refreshedTable = $schema->getTableSchema($tableName, false);
 
@@ -228,7 +228,7 @@ abstract class SchemaTest extends DatabaseTestCase
         $this->assertNotSame($noCacheTable, $refreshedTable);
 
         // Compare
-        $schema->db->setTablePrefix($testTablePrefix);
+        $schema->getDb()->setTablePrefix($testTablePrefix);
         $schema->refreshTableSchema($testTablePrefix);
         $testRefreshedTable = $schema->getTableSchema($testTableName, false);
 
@@ -244,11 +244,12 @@ abstract class SchemaTest extends DatabaseTestCase
 
         $table = $schema->getTableSchema('composite_fk');
 
-        $this->assertCount(1, $table->foreignKeys);
-        $this->assertTrue(isset($table->foreignKeys['FK_composite_fk_order_item']));
-        $this->assertEquals('order_item', $table->foreignKeys['FK_composite_fk_order_item'][0]);
-        $this->assertEquals('order_id', $table->foreignKeys['FK_composite_fk_order_item']['order_id']);
-        $this->assertEquals('item_id', $table->foreignKeys['FK_composite_fk_order_item']['item_id']);
+        $fk = $table->getForeignKeys();
+        $this->assertCount(1, $fk);
+        $this->assertTrue(isset($fk['FK_composite_fk_order_item']));
+        $this->assertEquals('order_item', $fk['FK_composite_fk_order_item'][0]);
+        $this->assertEquals('order_id', $fk['FK_composite_fk_order_item']['order_id']);
+        $this->assertEquals('item_id', $fk['FK_composite_fk_order_item']['item_id']);
     }
 
     public function testGetPDOType()
@@ -527,7 +528,7 @@ abstract class SchemaTest extends DatabaseTestCase
 
         $this->assertEquals($expectedColNames, $colNames);
 
-        foreach ($table->columns as $name => $column) {
+        foreach ($table->getColumns() as $name => $column) {
             $expected = $columns[$name];
             $this->assertSame(
                 $expected['dbType'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Tests pass?   | ✔️

- [x] add getters and setters.
- [x] move phpdoc property private to setters and getters.
- [x] change visibility property public to private.
- [x] fixed tests.
- [x] create TableSchema::class, property foreingKey, to each package implementation, since they are different in Mysql, Sqlite and Pgsql.
