### PR TITLE
Use string as error code

### DIFF
--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -20,10 +20,10 @@ class Exception extends \Exception
      *
      * @param string $message PDO error message
      * @param array|null $errorInfo PDO error info
-     * @param int $code PDO error code
+     * @param string $code PDO error code
      * @param \Exception $previous  The previous exception used for the exception chaining.
      */
-    public function __construct(string $message, ?array $errorInfo = [], int $code = 0, \Exception $previous = null)
+    public function __construct(string $message, ?array $errorInfo = [], string $code = '', \Exception $previous = null)
     {
         $this->errorInfo = $errorInfo;
         parent::__construct($message, $code, $previous);

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -727,7 +727,7 @@ abstract class Schema
         $message = $e->getMessage() . "\nThe SQL being executed was: $rawSql";
         $errorInfo = $e instanceof \PDOException ? $e->errorInfo : null;
 
-        return new $exceptionClass($message, $errorInfo, (int) $e->getCode(), $e);
+        return new $exceptionClass($message, $errorInfo, $e->getCode(), $e);
     }
 
     /**


### PR DESCRIPTION
Since that's what PDO uses and we're wrapping around it.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | https://github.com/yiisoft/yii2/issues/18203
