### PR TITLE
Adjust ConnectionInterface::class.

### DIFF
--- a/src/Connection/Connection.php
+++ b/src/Connection/Connection.php
@@ -169,7 +169,7 @@ use function is_array;
 abstract class Connection implements ConnectionInterface
 {
     private ?string $driverName = null;
-    private ?string $dsn = null;
+    private string $dsn;
     private ?string $username = null;
     private ?string $password = null;
     private array $attributes = [];
@@ -377,29 +377,7 @@ abstract class Connection implements ConnectionInterface
         return $this->charset;
     }
 
-    /**
-     * Returns the name of the DB driver. Based on the the current {@see dsn}, in case it was not set explicitly by an
-     * end user.
-     *
-     * @throws Exception
-     * @throws InvalidConfigException
-     *
-     * @return string|null name of the DB driver
-     */
-    public function getDriverName(): ?string
-    {
-        if ($this->driverName === null) {
-            if (($pos = strpos($this->dsn, ':')) !== false) {
-                $this->driverName = strtolower(substr($this->dsn, 0, $pos));
-            } else {
-                $this->driverName = strtolower($this->getSlavePdo()->getAttribute(PDO::ATTR_DRIVER_NAME));
-            }
-        }
-
-        return $this->driverName;
-    }
-
-    public function getDsn(): ?string
+    public function getDsn(): string
     {
         return $this->dsn;
     }

--- a/src/Connection/ConnectionInterface.php
+++ b/src/Connection/ConnectionInterface.php
@@ -26,18 +26,14 @@ interface ConnectionInterface
     public function createCommand(?string $sql = null, array $params = []): Command;
 
     /**
-     * Returns the name of the DB driver. Based on the the current {@see dsn}, in case it was not set explicitly by an
-     * end user.
+     * Returns the name of the DB driver.
      *
-     * @throws Exception
-     * @throws InvalidConfigException
-     *
-     * @return string|null name of the DB driver
+     * @return string name of the DB driver
      */
-    public function getDriverName(): ?string;
+    public function getDriverName(): string;
 
     /**
-     * @var string the Data Source Name, or DSN, contains the information required to connect to the database.
+     * @return string the Data Source Name, or DSN, contains the information required to connect to the database.
      *
      * Please refer to the [PHP manual](https://secure.php.net/manual/en/pdo.construct.php) on the format of the DSN
      * string.
@@ -47,7 +43,7 @@ interface ConnectionInterface
      *
      * {@see charset}
      */
-    public function getDsn(): ?string;
+    public function getDsn(): string;
 
     /**
      * Returns the schema information for the database opened by this connection.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️

- [x] Adjust class for support all packages db-mssql, db-sqlite, db-oracle, db-pgsql, db-mysql, db-redis.
- [x] Remove `null` returns.
- [x] Add simple `getDriverName()` method in each packages.

Example:

```php
/**
 * Returns the name of the DB driver.
 *
 * @return string name of the DB driver
 /
public function getDriverName(): string
{
    return 'pgsql';
}
```

The tests will fail as I must add the method to each package.
