### PR TITLE
Refactoring  class ColumnSchema and added class ColumnExtendedSchema

### DIFF
--- a/src/Schema/ColumnExtendedSchema.php
+++ b/src/Schema/ColumnExtendedSchema.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Db\Schema;
+
+/**
+ * ColumnExtendedSchema class describes the metadata of a column in a database table.
+ */
+class ColumnExtendedSchema extends ColumnSchema
+{
+    private ?int $maxChars = null;
+    private ?int $maxBytes = null;
+    private ?string $charset = null;
+    private ?string $check = null;
+
+    /**
+     * @return int|null
+     */
+    public function getMaxChars(): ?int
+    {
+        return $this->maxChars;
+    }
+
+    /**
+     * @param int|null $maxChars
+     */
+    public function setMaxChars(?int $maxChars): void
+    {
+        $this->maxChars = $maxChars;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getMaxBytes(): ?int
+    {
+        return $this->maxBytes;
+    }
+
+    /**
+     * @param int|null $maxBytes
+     */
+    public function setMaxBytes(?int $maxBytes): void
+    {
+        $this->maxBytes = $maxBytes;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getCharset(): ?string
+    {
+        return $this->charset;
+    }
+
+    /**
+     * @param string|null $charset
+     */
+    public function setCharset(?string $charset): void
+    {
+        $this->charset = $charset;
+    }
+
+    public function getCheck(): ?string
+    {
+        return $this->check;
+    }
+
+    public function setCheck(?string $check): void
+    {
+        $this->check = $check;
+    }
+}

--- a/src/Schema/ColumnSchema.php
+++ b/src/Schema/ColumnSchema.php
@@ -15,6 +15,8 @@ use Yiisoft\Strings\NumericHelper;
  */
 class ColumnSchema
 {
+    private ?string $schemaName;
+    private string $tableName;
     private string $name;
     private bool $allowNull;
     private string $type;
@@ -30,8 +32,15 @@ class ColumnSchema
     private bool $unsigned = false;
     private ?string $comment = null;
 
+    public function __construct(?string $schemaName, string $tableName, string $name)
+    {
+        $this->schemaName = $schemaName;
+        $this->tableName = $tableName;
+        $this->name = $name;
+    }
+
     /**
-     * Converts the input value according to {@see phpType} after retrieval from the database.
+     * Converts the input value according to {@see setPhpType} after retrieval from the database.
      *
      * If the value is null or an {@see Expression}, it will not be converted.
      *
@@ -45,7 +54,7 @@ class ColumnSchema
     }
 
     /**
-     * Converts the input value according to {@see type} and {@see dbType} for use in a db query.
+     * Converts the input value according to {@see type} and {@see setDbType} for use in a db query.
      *
      * If the value is null or an {@see Expression}, it will not be converted.
      *
@@ -63,8 +72,213 @@ class ColumnSchema
         return $this->typecast($value);
     }
 
+    public function getSchemaName(): ?string
+    {
+        return $this->schemaName;
+    }
+
+    public function setSchemaName(?string $schemaName): void
+    {
+        $this->schemaName = $schemaName;
+    }
+
+    public function getTableName(): string
+    {
+        return $this->tableName;
+    }
+
+    public function setTableName(string $tableName): void
+    {
+        $this->tableName = $tableName;
+    }
+
     /**
-     * Converts the input value according to {@see phpType} after retrieval from the database.
+     * @return string name of this column (without quotes).
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $value): void
+    {
+        $this->name = $value;
+    }
+
+    /**
+     * @return bool whether this column can be null.
+     */
+    public function isAllowNull(): bool
+    {
+        return $this->allowNull;
+    }
+
+    public function setAllowNull(bool $value): void
+    {
+        $this->allowNull = $value;
+    }
+
+    /**
+     * @return string abstract type of this column. Possible abstract types include: char, string, text, boolean,
+     * smallint, integer, bigint, float, decimal, datetime, timestamp, time, date, binary, and money.
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function setType(string $value): void
+    {
+        $this->type = $value;
+    }
+
+    /**
+     * @return string the PHP type of this column. Possible PHP types include: `string`, `boolean`, `integer`,
+     * `double`, `array`.
+     */
+    public function getPhpType(): ?string
+    {
+        return $this->phpType;
+    }
+
+    public function setPhpType(?string $value): void
+    {
+        $this->phpType = $value;
+    }
+
+    /**
+     * @return string the DB type of this column. Possible DB types vary according to the type of DBMS.
+     */
+    public function getDbType(): string
+    {
+        return $this->dbType;
+    }
+
+    public function setDbType(string $value): void
+    {
+        $this->dbType = $value;
+    }
+
+    /**
+     * @return mixed default value of this column
+     */
+    public function getDefaultValue()
+    {
+        return $this->defaultValue;
+    }
+
+    public function defaultValue($value): void
+    {
+        $this->defaultValue = $value;
+    }
+
+    /**
+     * @return array enumerable values. This is set only if the column is declared to be an enumerable type.
+     */
+    public function getEnumValues(): ?array
+    {
+        return $this->enumValues;
+    }
+
+    public function setEnumValues(?array $value): void
+    {
+        $this->enumValues = $value;
+    }
+
+    /**
+     * @return int display size of the column.
+     */
+    public function getSize(): ?int
+    {
+        return $this->size;
+    }
+
+    public function setSize(?int $value): void
+    {
+        $this->size = $value;
+    }
+
+    /**
+     * @return int precision of the column data, if it is numeric.
+     */
+    public function getPrecision(): ?int
+    {
+        return $this->precision;
+    }
+
+    public function setPrecision(?int $value): void
+    {
+        $this->precision = $value;
+    }
+
+    /**
+     * @return int scale of the column data, if it is numeric.
+     */
+    public function getScale(): ?int
+    {
+        return $this->scale;
+    }
+
+    public function setScale(?int $value): void
+    {
+        $this->scale = $value;
+    }
+
+    /**
+     * @return bool whether this column is a primary key
+     */
+    public function isPrimaryKey(): bool
+    {
+        return $this->isPrimaryKey;
+    }
+
+    /**
+     * @return bool whether this column is auto-incremental
+     */
+    public function isAutoIncrement(): bool
+    {
+        return $this->autoIncrement;
+    }
+
+    public function setPrimaryKey(bool $value): void
+    {
+        $this->isPrimaryKey = $value;
+    }
+
+    public function setAutoIncrement(bool $value): void
+    {
+        $this->autoIncrement = $value;
+    }
+
+    /**
+     * @return bool whether this column is unsigned. This is only meaningful when {@see type} is `smallint`, `integer`
+     * or `bigint`.
+     */
+    public function isUnsigned(): bool
+    {
+        return $this->unsigned;
+    }
+
+    public function setUnsigned(bool $value): void
+    {
+        $this->unsigned = $value;
+    }
+
+    /**
+     * @return string comment of this column. Not all DBMS support this.
+     */
+    public function getComment(): ?string
+    {
+        return $this->comment;
+    }
+
+    public function setComment(?string $value): void
+    {
+        $this->comment = $value;
+    }
+
+    /**
+     * Converts the input value according to {@see setPhpType} after retrieval from the database.
      *
      * If the value is null or an {@see Expression}, it will not be converted.
      *
@@ -87,7 +301,7 @@ class ColumnSchema
                 true
             )
         ) {
-            return;
+            return null;
         }
 
         if (
@@ -117,24 +331,24 @@ class ColumnSchema
 
                 if (is_float($value)) {
                     /* ensure type cast always has . as decimal separator in all locales */
-                    return NumericHelper::normalize((string) $value);
+                    return NumericHelper::normalize((string)$value);
                 }
 
                 if (is_bool($value)) {
                     return $value ? '1' : '0';
                 }
 
-                return (string) $value;
+                return (string)$value;
             case 'integer':
-                return (int) $value;
+                return (int)$value;
             case 'boolean':
                 /**
                  * treating a 0 bit value as false too
                  * https://github.com/yiisoft/yii2/issues/9006
                  */
-                return (bool) $value && $value !== "\0";
+                return (bool)$value && $value !== "\0";
             case 'double':
-                return (float) $value;
+                return (float)$value;
         }
 
         return $value;
@@ -153,195 +367,5 @@ class ColumnSchema
             PDO::PARAM_NULL,
             PDO::PARAM_STMT
         ];
-    }
-
-    public function setType(string $value): void
-    {
-        $this->type = $value;
-    }
-
-    /**
-     * @return string name of this column (without quotes).
-     */
-    public function getName(): string
-    {
-        return $this->name;
-    }
-
-    /**
-     * @return bool whether this column can be null.
-     */
-    public function isAllowNull(): bool
-    {
-        return $this->allowNull;
-    }
-
-    /**
-     * @return string abstract type of this column. Possible abstract types include: char, string, text, boolean,
-     * smallint, integer, bigint, float, decimal, datetime, timestamp, time, date, binary, and money.
-     */
-    public function getType(): string
-    {
-        return $this->type;
-    }
-
-    /**
-     * @return string the PHP type of this column. Possible PHP types include: `string`, `boolean`, `integer`,
-     * `double`, `array`.
-     */
-    public function getPhpType(): ?string
-    {
-        return $this->phpType;
-    }
-
-    /**
-     * @return string the DB type of this column. Possible DB types vary according to the type of DBMS.
-     */
-    public function getDbType(): string
-    {
-        return $this->dbType;
-    }
-
-    /**
-     * @return mixed default value of this column
-     */
-    public function getDefaultValue()
-    {
-        return $this->defaultValue;
-    }
-
-    /**
-     * @return array enumerable values. This is set only if the column is declared to be an enumerable type.
-     */
-    public function getEnumValues(): ?array
-    {
-        return $this->enumValues;
-    }
-
-    /**
-     * @return int display size of the column.
-     */
-    public function getSize(): ?int
-    {
-        return $this->size;
-    }
-
-    /**
-     * @return int precision of the column data, if it is numeric.
-     */
-    public function getPrecision(): ?int
-    {
-        return $this->precision;
-    }
-
-    /**
-     * @return int scale of the column data, if it is numeric.
-     */
-    public function getScale(): ?int
-    {
-        return $this->scale;
-    }
-
-    /**
-     * @return bool whether this column is a primary key
-     */
-    public function isPrimaryKey(): bool
-    {
-        return $this->isPrimaryKey;
-    }
-
-    /**
-     * @return bool whether this column is auto-incremental
-     */
-    public function isAutoIncrement(): bool
-    {
-        return $this->autoIncrement;
-    }
-
-    /**
-     * @return bool whether this column is unsigned. This is only meaningful when {@see type} is `smallint`, `integer`
-     * or `bigint`.
-     */
-    public function isUnsigned(): bool
-    {
-        return $this->unsigned;
-    }
-
-    /**
-     * @return string comment of this column. Not all DBMS support this.
-     */
-    public function getComment(): ?string
-    {
-        return $this->comment;
-    }
-
-    public function name(string $value): void
-    {
-        $this->name = $value;
-    }
-
-    public function allowNull(bool $value): void
-    {
-        $this->allowNull =  $value;
-    }
-
-    public function type(string $value): void
-    {
-        $this->type = $value;
-    }
-
-    public function phpType(?string $value): void
-    {
-        $this->phpType = $value;
-    }
-
-    public function dbType(string $value): void
-    {
-        $this->dbType = $value;
-    }
-
-    public function defaultValue($value): void
-    {
-        $this->defaultValue = $value;
-    }
-
-    public function enumValues(?array $value): void
-    {
-        $this->enumValues = $value;
-    }
-
-    public function size(?int $value): void
-    {
-        $this->size = $value;
-    }
-
-    public function precision(?int $value): void
-    {
-        $this->precision = $value;
-    }
-
-    public function scale(?int $value): void
-    {
-        $this->scale = $value;
-    }
-
-    public function primaryKey(bool $value): void
-    {
-        $this->isPrimaryKey = $value;
-    }
-
-    public function autoIncrement(bool $value): void
-    {
-        $this->autoIncrement = $value;
-    }
-
-    public function unsigned(bool $value): void
-    {
-        $this->unsigned = $value;
-    }
-
-    public function comment(?string $value): void
-    {
-        $this->comment = $value;
     }
 }

--- a/src/Schema/TableSchema.php
+++ b/src/Schema/TableSchema.php
@@ -27,9 +27,9 @@ abstract class TableSchema
      *
      * @param string $name column name
      *
-     * @return ColumnSchema metadata of the named column. Null if the named column does not exist.
+     * @return ColumnSchema|null metadata of the named column. Null if the named column does not exist.
      */
-    public function getColumn(?string $name): ColumnSchema
+    public function getColumn(string $name): ?ColumnSchema
     {
         return $this->columns[$name] ?? null;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | 

- For the `ColumnSchema.php` class, all setters have a `set` added.

- For class `ColumnSchema.php` added fields `$schemaName`, `$tableName`;

- For the `ColumnSchema.php` class, the setters for the properties field `$name` are removed, their setting has been moved to the constructor.

- Added class `ColumnExtendedSchema`:

```php
class ColumnExtendedSchema extends ColumnSchema
{
    private ?int $maxChars = null;
    private ?int $maxBytes = null;
    private ?string $charset = null;
    private ?string $check = null;

    ...
}
```

It would be nice if components like gii could request this information to better generate models. Not all drivers will be able to give this information, but it is better to make it common so that components like `gii` would not think about what driver is.

**PS:** If the PR is accepted, I will PR for other packages that used these setters.