### PR TITLE
Replace Connection to ConnectionInterface

### DIFF
--- a/src/Connection/Connection.php
+++ b/src/Connection/Connection.php
@@ -98,7 +98,7 @@ use function strncmp;
  * If needed you can pass transaction isolation level as a second parameter:
  *
  * ```php
- * $connection->transaction(function (Connection $db) {
+ * $connection->transaction(function (ConnectionInterface $db) {
  *     //return $db->...
  * }, Transaction::READ_UNCOMMITTED);
  * ```
@@ -308,7 +308,7 @@ abstract class Connection implements ConnectionInterface
      * ```php
      * // The customer will be fetched from cache if available.
      * // If not, the query will be made against DB and cached for use next time.
-     * $customer = $db->cache(function (Connection $db) {
+     * $customer = $db->cache(function (ConnectionInterface $db) {
      *     return $db->createCommand('SELECT * FROM customer WHERE id=1')->queryOne();
      * });
      * ```
@@ -317,7 +317,7 @@ abstract class Connection implements ConnectionInterface
      * {@see Command::execute()}, query cache will not be used.
      *
      * @param callable $callable a PHP callable that contains DB queries which will make use of query cache.
-     * The signature of the callable is `function (Connection $db)`.
+     * The signature of the callable is `function (ConnectionInterface $db)`.
      * @param int|null $duration the number of seconds that query results can remain valid in the cache. If this is not
      * set, the value of {@see queryCacheDuration} will be used instead. Use 0 to indicate that the cached data will
      * never expire.
@@ -561,11 +561,11 @@ abstract class Connection implements ConnectionInterface
      * Queries performed within the callable will not use query cache at all. For example,
      *
      * ```php
-     * $db->cache(function (Connection $db) {
+     * $db->cache(function (ConnectionInterface $db) {
      *
      *     // ... queries that use query cache ...
      *
-     *     return $db->noCache(function (Connection $db) {
+     *     return $db->noCache(function (ConnectionInterface $db) {
      *         // this query will not use query cache
      *         return $db->createCommand('SELECT * FROM customer WHERE id=1')->queryOne();
      *     });
@@ -573,7 +573,7 @@ abstract class Connection implements ConnectionInterface
      * ```
      *
      * @param callable $callable a PHP callable that contains DB queries which should not use query cache. The signature
-     * of the callable is `function (Connection $db)`.
+     * of the callable is `function (ConnectionInterface $db)`.
      *
      * @throws Throwable if there is any exception during query
      *
@@ -1046,13 +1046,13 @@ abstract class Connection implements ConnectionInterface
      * even if they are read queries. For example,
      *
      * ```php
-     * $result = $db->useMaster(function ($db) {
+     * $result = $db->useMaster(function (ConnectionInterface $db) {
      *     return $db->createCommand('SELECT * FROM user LIMIT 1')->queryOne();
      * });
      * ```
      *
      * @param callable $callback a PHP callable to be executed by this method. Its signature is
-     * `function (Connection $db)`. Its return value will be returned by this method.
+     * `function (ConnectionInterface $db)`. Its return value will be returned by this method.
      *
      * @throws Throwable if there is any exception thrown from the callback
      *

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -6,7 +6,7 @@ namespace Yiisoft\Db\Query;
 
 use Generator;
 use JsonException;
-use Yiisoft\Db\Connection\Connection;
+use Yiisoft\Db\Connection\ConnectionInterface;
 use Yiisoft\Db\Constraint\Constraint;
 use Yiisoft\Db\Constraint\ConstraintFinderInterface;
 use Yiisoft\Db\Exception\Exception;
@@ -128,9 +128,9 @@ class QueryBuilder
      */
     protected array $expressionBuilders = [];
     protected string $separator = ' ';
-    private Connection $db;
+    private ConnectionInterface $db;
 
-    public function __construct(Connection $db)
+    public function __construct(ConnectionInterface $db)
     {
         $this->db = $db;
         $this->expressionBuilders = $this->defaultExpressionBuilders();
@@ -1962,7 +1962,7 @@ class QueryBuilder
         return 'WITH ' . ($recursive ? 'RECURSIVE ' : '') . implode(', ', $result);
     }
 
-    public function getDb(): Connection
+    public function getDb(): ConnectionInterface
     {
         return $this->db;
     }

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -9,7 +9,7 @@ use PDOException;
 use Throwable;
 use Yiisoft\Cache\Dependency\TagDependency;
 use Yiisoft\Db\Cache\SchemaCache;
-use Yiisoft\Db\Connection\Connection;
+use Yiisoft\Db\Connection\ConnectionInterface;
 use Yiisoft\Db\Exception\Exception;
 use Yiisoft\Db\Exception\IntegrityException;
 use Yiisoft\Db\Exception\InvalidCallException;
@@ -113,11 +113,11 @@ abstract class Schema
     private array $tableNames = [];
     private array $tableMetadata = [];
     private ?string $serverVersion = null;
-    private Connection $db;
+    private ConnectionInterface $db;
     private ?QueryBuilder $builder = null;
     private SchemaCache $schemaCache;
 
-    public function __construct(Connection $db, SchemaCache $schemaCache)
+    public function __construct(ConnectionInterface $db, SchemaCache $schemaCache)
     {
         $this->db = $db;
         $this->schemaCache = $schemaCache;
@@ -942,7 +942,7 @@ abstract class Schema
         );
     }
 
-    public function getDb(): Connection
+    public function getDb(): ConnectionInterface
     {
         return $this->db;
     }

--- a/src/TestUtility/TestQueryBuilderTrait.php
+++ b/src/TestUtility/TestQueryBuilderTrait.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Db\TestUtility;
 
-use Yiisoft\Db\Connection\Connection;
+use Yiisoft\Db\Connection\ConnectionInterface;
 use Yiisoft\Db\Expression\Expression;
 use Yiisoft\Db\Query\Conditions\InCondition;
 use Yiisoft\Db\Query\Conditions\LikeCondition;
@@ -27,7 +27,7 @@ trait TestQueryBuilderTrait
 {
     use SchemaBuilderTrait;
 
-    public function getDb(): Connection
+    public function getDb(): ConnectionInterface
     {
         return $this->getConnection();
     }

--- a/src/TestUtility/TestQueryTrait.php
+++ b/src/TestUtility/TestQueryTrait.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Db\TestUtility;
 
-use Yiisoft\Db\Connection\Connection;
+use Yiisoft\Db\Connection\ConnectionInterface;
 use Yiisoft\Db\Exception\Exception;
 use Yiisoft\Db\Exception\InvalidArgumentException;
 use Yiisoft\Db\Exception\InvalidConfigException;
@@ -814,7 +814,7 @@ trait TestQueryTrait
         );
 
         /* Connection cache */
-        $db->cache(function (Connection $db) use ($query, $update) {
+        $db->cache(function (ConnectionInterface $db) use ($query, $update) {
             $this->assertEquals(
                 'user2',
                 $query->where(['id' => 2])->scalar(),

--- a/src/Transaction/Transaction.php
+++ b/src/Transaction/Transaction.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Db\Transaction;
 use Psr\Log\LogLevel;
 use Throwable;
 use Yiisoft\Db\AwareTrait\LoggerAwareTrait;
-use Yiisoft\Db\Connection\Connection;
+use Yiisoft\Db\Connection\ConnectionInterface;
 use Yiisoft\Db\Exception\Exception;
 use Yiisoft\Db\Exception\InvalidConfigException;
 use Yiisoft\Db\Exception\NotSupportedException;
@@ -72,9 +72,9 @@ class Transaction
     public const SERIALIZABLE = 'SERIALIZABLE';
 
     private int $level = 0;
-    private Connection $db;
+    private ConnectionInterface $db;
 
-    public function __construct(Connection $db)
+    public function __construct(ConnectionInterface $db)
     {
         $this->db = $db;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

This fix is ​​required so that you can use QueryBuilder with databases that work without a PDO connection. Examples of such databases are Clickhouse and restream/reindexer