### PR TITLE
Ability to disable auto slave select for all read queries

### DIFF
--- a/src/Command/Command.php
+++ b/src/Command/Command.php
@@ -280,7 +280,7 @@ class Command
 
         $sql = $this->getSql();
 
-        if ($this->db->getTransaction()) {
+        if ($this->db->getTransaction() || !$this->db->isAutoSlaveForReadQueriesEnabled()) {
             /** master is in a transaction. use the same connection. */
             $forRead = false;
         }

--- a/src/Connection/Connection.php
+++ b/src/Connection/Connection.php
@@ -176,6 +176,7 @@ abstract class Connection implements ConnectionInterface
     private bool $enableSavepoint = true;
     private int $serverRetryInterval = 600;
     private bool $enableSlaves = true;
+    private bool $enableAutoSlaveForReadQueries = true;
     private array $slaves = [];
     private array $masters = [];
     private bool $shuffleMasters = true;
@@ -370,6 +371,11 @@ abstract class Connection implements ConnectionInterface
     public function areSlavesEnabled(): bool
     {
         return $this->enableSlaves;
+    }
+
+    public function isAutoSlaveForReadQueriesEnabled(): bool
+    {
+        return $this->enableAutoSlaveForReadQueries;
     }
 
     /**
@@ -886,6 +892,11 @@ abstract class Connection implements ConnectionInterface
     public function setEnableSlaves(bool $value): void
     {
         $this->enableSlaves = $value;
+    }
+
+    public function setEnableAutoSlaveForReadQueries(bool $value): void
+    {
+        $this->enableAutoSlaveForReadQueries = $value;
     }
 
     /**

--- a/src/Connection/ConnectionInterface.php
+++ b/src/Connection/ConnectionInterface.php
@@ -70,6 +70,15 @@ interface ConnectionInterface
     public function getTableSchema(string $name, $refresh = false): ?TableSchema;
 
     /**
+     * Whether to enable auto recogintion of read queries and use slave (if enabled) for execute
+     *
+     * @return bool:
+     *  true -> (default) use slave for read queries, master for other
+     *  false -> always use master connection (for reads and writes). Slave still can be used via $this->getSlave()
+     */
+    public function isAutoSlaveForReadQueriesEnabled(): bool;
+
+    /**
      * Whether to enable read/write splitting by using {@see setSlaves()} to read data. Note that if {@see setSlaves()}
      * is empty, read/write splitting will NOT be enabled no matter what value this property takes.
      *

--- a/src/Connection/ConnectionInterface.php
+++ b/src/Connection/ConnectionInterface.php
@@ -70,11 +70,10 @@ interface ConnectionInterface
     public function getTableSchema(string $name, $refresh = false): ?TableSchema;
 
     /**
-     * Whether to enable auto-detection of read queries and use slave (if enabled) for execute
+     * Whether to enable auto recogintion of read queries and use slave (if enabled) for execute.
      *
-     * @return bool:
-     *  true -> (default) use slave for read queries, master for other
-     *  false -> always use master connection (for reads and writes). Slave still can be used via $this->getSlave()
+     * @return bool For default `true` use slave for read queries, `false` use master connection (for reads and writes).
+     * Slave still can be used via $this->getSlave().
      */
     public function isAutoSlaveForReadQueriesEnabled(): bool;
 

--- a/src/Connection/ConnectionInterface.php
+++ b/src/Connection/ConnectionInterface.php
@@ -70,7 +70,7 @@ interface ConnectionInterface
     public function getTableSchema(string $name, $refresh = false): ?TableSchema;
 
     /**
-     * Whether to enable auto recogintion of read queries and use slave (if enabled) for execute
+     * Whether to enable auto-detection of read queries and use slave (if enabled) for execute
      *
      * @return bool:
      *  true -> (default) use slave for read queries, master for other

--- a/src/TestUtility/TestConnectionTrait.php
+++ b/src/TestUtility/TestConnectionTrait.php
@@ -384,4 +384,13 @@ trait TestConnectionTrait
         $this->assertNull($conn3->getTransaction());
         $this->assertNull($conn3->getPDO());
     }
+
+    public function testDisableAutoSlaveForReads(): void
+    {
+        $db = $this->getConnection();
+        $this->assertTrue($db->isAutoSlaveForReadQueriesEnabled());
+
+        $db->setEnableAutoSlaveForReadQueries(false);
+        $this->assertFalse($db->isAutoSlaveForReadQueriesEnabled());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌

New boolean flag for `Connection`:
Ability to disable auto slave select for all read queries. Slave connection still can be used  with `$db->getSlave()` method


