### PR TITLE
Fix table alias regexp in QueryHelper#cleanUpTableNames()

### DIFF
--- a/src/Query/Helper/QueryHelper.php
+++ b/src/Query/Helper/QueryHelper.php
@@ -39,7 +39,7 @@ final class QueryHelper
     {
         $cleanedUpTableNames = [];
         $pattern = <<<PATTERN
-        ~^\s*((?:['"`\[]|{{).*?(?:['"`\]]|}})|\(.*?\)|.*?)(?:(?:\s+(?:as)?\s*)((?:['"`\[]|{{).*?(?:['"`\]]|}})|.*?))?\s*$~iux
+        ~^\s*((?:['"`\[]|{{).*?(?:['"`\]]|}})|\(.*?\)|.*?)(?:(?:\s+(?:as\s+)?)((?:['"`\[]|{{).*?(?:['"`\]]|}})|.*?))?\s*$~iux
         PATTERN;
 
         /** @psalm-var array<array-key, Expression|string> $tableNames */

--- a/tests/QueryHelperTest.php
+++ b/tests/QueryHelperTest.php
@@ -18,6 +18,7 @@ final class QueryHelperTest extends TestCase
         return [
             [['customer'], '', ['{{customer}}' => '{{customer}}']],
             [['profile AS "prf"'], '', ['{{prf}}' => '{{profile}}']],
+            [['mainframe as400'], '', ['{{as400}}' => '{{mainframe}}']],
             [
                 ['x' => new Expression('(SELECT id FROM user)')],
                 '',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -

Table name with alias `mainframe as400`:
- Currently: `{{400}} -> {{mainframe}}`
- Expected: `{{as400}} -> {{mainframe}}`
