### PR TITLE
Feature fix null operand

### DIFF
--- a/src/QueryBuilder/Conditions/SimpleCondition.php
+++ b/src/QueryBuilder/Conditions/SimpleCondition.php
@@ -41,25 +41,29 @@ final class SimpleCondition implements SimpleConditionInterface
      */
     public static function fromArrayDefinition(string $operator, array $operands): self
     {
-        if (!isset($operands[0], $operands[1])) {
-            throw new InvalidArgumentException("Operator '$operator' requires two operands.");
+        if (!isset($operands[0])) {
+            throw new InvalidArgumentException("Operator '$operator' requires column.");
+        }
+
+        if (!array_key_exists(1, $operands)) {
+            throw new InvalidArgumentException("Operator '$operator' requires value as second operand.");
         }
 
         return new self(self::validateColumn($operator, $operands[0]), $operator, $operands[1]);
     }
 
-    private static function validateColumn(string $operator, mixed $operands): string|Expression|QueryInterface
+    private static function validateColumn(string $operator, mixed $column): string|Expression|QueryInterface
     {
         if (
-            !is_string($operands) &&
-            !($operands instanceof Expression) &&
-            !($operands instanceof QueryInterface)
+            !is_string($column) &&
+            !($column instanceof Expression) &&
+            !($column instanceof QueryInterface)
         ) {
             throw new InvalidArgumentException(
                 "Operator '$operator' requires column to be string, ExpressionInterface or QueryInterface."
             );
         }
 
-        return $operands;
+        return $column;
     }
 }

--- a/tests/QueryBuilder/Condition/SimpleConditionTest.php
+++ b/tests/QueryBuilder/Condition/SimpleConditionTest.php
@@ -31,11 +31,18 @@ final class SimpleConditionTest extends TestCase
         $this->assertSame(1, $simpleCondition->getValue());
     }
 
-    public function testFromArrayDefinitionException(): void
+    public function testFromArrayDefinitionColumnException(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("Operator '=' requires two operands.");
+        $this->expectExceptionMessage("Operator '=' requires column.");
         SimpleCondition::fromArrayDefinition('=', []);
+    }
+
+    public function testFromArrayDefinitionValueException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Operator 'IN' requires value as second operand.");
+        SimpleCondition::fromArrayDefinition('IN', ['column']);
     }
 
     public function testFromArrayDefinitionExceptionColumn(): void
@@ -45,5 +52,15 @@ final class SimpleConditionTest extends TestCase
             "Operator '=' requires column to be string, ExpressionInterface or QueryInterface."
         );
         SimpleCondition::fromArrayDefinition('=', [1, 1]);
+    }
+
+    public function testNullSecondOperand(): void
+    {
+        $condition = SimpleCondition::fromArrayDefinition('=', ['id', null]);
+        $this->assertNull($condition->getValue());
+
+        $condition2 = new SimpleCondition('name', 'IS NOT', null);
+        $this->assertSame('IS NOT', $condition2->getOperator());
+        $this->assertNull($condition2->getValue());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

After some changes there is not allowed to use NULL as value in query conditions. This PR return this feature with some tests