### PR TITLE
Fix 9: Move `truncateTable()` to `DDLQueryBuilder::class`.

### DIFF
--- a/src/QueryBuilder/DDLQueryBuilderInterface.php
+++ b/src/QueryBuilder/DDLQueryBuilderInterface.php
@@ -378,4 +378,13 @@ interface DDLQueryBuilderInterface
      * @return string the SQL statement for renaming a DB table.
      */
     public function renameTable(string $oldName, string $newName): string;
+
+    /**
+     * Builds a SQL statement for truncating a DB table.
+     *
+     * @param string $table the table to be truncated. The name will be properly quoted by the method.
+     *
+     * @return string the SQL statement for truncating a DB table.
+     */
+    public function truncateTable(string $table): string;
 }

--- a/src/QueryBuilder/DMLQueryBuilder.php
+++ b/src/QueryBuilder/DMLQueryBuilder.php
@@ -135,11 +135,6 @@ abstract class DMLQueryBuilder implements DMLQueryBuilderInterface
         throw new NotSupportedException(static::class . ' does not support resetting sequence.');
     }
 
-    public function truncateTable(string $table): string
-    {
-        return 'TRUNCATE TABLE ' . $this->quoter->quoteTableName($table);
-    }
-
     /**
      * @psalm-suppress MixedArgument
      */

--- a/src/QueryBuilder/DMLQueryBuilderInterface.php
+++ b/src/QueryBuilder/DMLQueryBuilderInterface.php
@@ -119,15 +119,6 @@ interface DMLQueryBuilderInterface
     public function resetSequence(string $tableName, int|string|null $value = null): string;
 
     /**
-     * Builds a SQL statement for truncating a DB table.
-     *
-     * @param string $table the table to be truncated. The name will be properly quoted by the method.
-     *
-     * @return string the SQL statement for truncating a DB table.
-     */
-    public function truncateTable(string $table): string;
-
-    /**
      * Creates an UPDATE SQL statement.
      *
      * For example,

--- a/src/QueryBuilder/QueryBuilder.php
+++ b/src/QueryBuilder/QueryBuilder.php
@@ -405,7 +405,7 @@ abstract class QueryBuilder implements QueryBuilderInterface
 
     public function truncateTable(string $table): string
     {
-        return $this->dmlBuilder->truncateTable($table);
+        return $this->ddlBuilder->truncateTable($table);
     }
 
     public function update(string $table, array $columns, array|string $condition, array &$params = []): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
