### PR TITLE
Support for MySQL ANSI/ANSI_QUOTES modes

### DIFF
--- a/tests/Provider/ColumnTypes.php
+++ b/tests/Provider/ColumnTypes.php
@@ -134,13 +134,13 @@ final class ColumnTypes extends AbstractMigrationBuilder
                 $this->char()->check('value LIKE \'test%\''),
                 [
                     'pgsql' => 'char(1) CHECK (value LIKE \'test%\')',
+                    'mysql' => 'char(1) CHECK (value LIKE \'test%\')',
                 ],
             ],
             [
                 SchemaInterface::TYPE_CHAR . ' CHECK (value LIKE "test%")',
                 $this->char()->check('value LIKE "test%"'),
                 [
-                    'mysql' => 'char(1) CHECK (value LIKE "test%")',
                     'sqlite' => 'char(1) CHECK (value LIKE "test%")',
                 ],
             ],
@@ -158,8 +158,14 @@ final class ColumnTypes extends AbstractMigrationBuilder
                 SchemaInterface::TYPE_CHAR . '(6) CHECK (value LIKE "test%")',
                 $this->char(6)->check('value LIKE "test%"'),
                 [
-                    'mysql' => 'char(6) CHECK (value LIKE "test%")',
                     'sqlite' => 'char(6) CHECK (value LIKE "test%")',
+                ],
+            ],
+            [
+                SchemaInterface::TYPE_CHAR . '(6) CHECK (value LIKE \'test%\')',
+                $this->char(6)->check('value LIKE \'test%\''),
+                [
+                    'mysql' => 'char(6) CHECK (value LIKE \'test%\')',
                 ],
             ],
             [


### PR DESCRIPTION
https://github.com/yiisoft/yii2/pull/18500

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Breaks BC?    | ❌

This PR adds support for MySQL’s ANSI and ANSI_QUOTES modes, by checking for " characters in addition to ` whenever parsing the results of a SHOW CREATE TABLE command.

ANSI_QUOTES is enabled by default on DigitalOcean for MySQL 8, so it would be great to get this pulled in.
