### PR TITLE
Allow optional databaseName in constructor for `DsnSocket::class`.

### DIFF
--- a/src/Connection/AbstractDsnSocket.php
+++ b/src/Connection/AbstractDsnSocket.php
@@ -22,14 +22,18 @@ abstract class AbstractDsnSocket implements DsnInterface, Stringable
     public function __construct(
         private string $driver,
         private string $unixSocket,
-        private string $databaseName,
+        private string|null $databaseName = null,
         private array $options = []
     ) {
     }
 
     public function asString(): string
     {
-        $dsn = "$this->driver:" . "unix_socket=$this->unixSocket" . ';' . "dbname=$this->databaseName";
+        $dsn = "$this->driver:" . "unix_socket=$this->unixSocket";
+
+        if ($this->databaseName !== null && $this->databaseName !== '') {
+            $dsn .= ';' . "dbname=$this->databaseName";
+        }
 
         $parts = [];
 

--- a/tests/Db/Connection/DsnSocketTest.php
+++ b/tests/Db/Connection/DsnSocketTest.php
@@ -52,6 +52,14 @@ final class DsnSocketTest extends TestCase
         );
     }
 
+    public function testGetDsnWithoutDatabaseName(): void
+    {
+        $dsn = new DsnSocket('mysql', '/var/run/mysqld/mysqld.sock');
+
+        $this->assertSame('mysql:unix_socket=/var/run/mysqld/mysqld.sock', $dsn->asString());
+        $this->assertSame('mysql:unix_socket=/var/run/mysqld/mysqld.sock', $dsn->__toString());
+    }
+
     public function testGetOptions(): void
     {
         $dsn = new DsnSocket('mysql', '/var/run/mysqld/mysqld.sock', 'yiitest', ['charset' => 'utf8']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
