### PR TITLE
Support DateTime instances

### DIFF
--- a/src/Schema/AbstractSchema.php
+++ b/src/Schema/AbstractSchema.php
@@ -418,6 +418,11 @@ abstract class AbstractSchema implements SchemaInterface
             SchemaInterface::TYPE_DOUBLE => SchemaInterface::PHP_TYPE_DOUBLE,
             SchemaInterface::TYPE_BINARY => SchemaInterface::PHP_TYPE_RESOURCE,
             SchemaInterface::TYPE_JSON => SchemaInterface::PHP_TYPE_ARRAY,
+            SchemaInterface::TYPE_DATETIME => SchemaInterface::PHP_TYPE_DATE_TIME,
+            SchemaInterface::TYPE_TIMESTAMP => SchemaInterface::PHP_TYPE_DATE_TIME,
+            SchemaInterface::TYPE_DATE => SchemaInterface::PHP_TYPE_DATE_TIME,
+            SchemaInterface::TYPE_TIME => SchemaInterface::PHP_TYPE_DATE_TIME,
+
             default => SchemaInterface::PHP_TYPE_STRING,
         };
     }
@@ -647,5 +652,31 @@ abstract class AbstractSchema implements SchemaInterface
         }
 
         return (array) $this->viewNames[$schema];
+    }
+
+    protected function getDateTimeFormat(ColumnSchemaInterface $column): string|null
+    {
+        return match ($column->getType()) {
+            self::TYPE_TIMESTAMP,
+            self::TYPE_DATETIME => 'Y-m-d H:i:s'
+                . $this->getMillisecondsFormat($column)
+                . ($column->hasTimezone() ? 'P' : ''),
+            self::TYPE_DATE => 'Y-m-d',
+            self::TYPE_TIME => 'H:i:s'
+                . $this->getMillisecondsFormat($column)
+                . ($column->hasTimezone() ? 'P' : ''),
+            default => null,
+        };
+    }
+
+    protected function getMillisecondsFormat(ColumnSchemaInterface $column): string
+    {
+        $precision = $column->getPrecision();
+
+        return match (true) {
+            $precision > 3 => '.u',
+            $precision > 0 => '.v',
+            default => '',
+        };
     }
 }

--- a/src/Schema/ColumnSchemaInterface.php
+++ b/src/Schema/ColumnSchemaInterface.php
@@ -65,6 +65,13 @@ interface ColumnSchemaInterface
     public function computed(bool $value): void;
 
     /**
+     * The datetime format to convert value from `DateTimeInterface` to a database representation.
+     *
+     * It defines from table schema.
+     */
+    public function dateTimeFormat(string|null $value): void;
+
+    /**
      * The database data-type of column.
      *
      * The data type can be one of the built-in data types supported by the database server (such as `INTEGER`, `VARCHAR`,
@@ -133,6 +140,13 @@ interface ColumnSchemaInterface
      * @see comment()
      */
     public function getComment(): string|null;
+
+    /**
+     * @return string|null The datetime format.
+     *
+     * @see dateTimeFormat()
+     */
+    public function getDateTimeFormat(): string|null;
 
     /**
      * @return string|null The database type of the column.
@@ -205,6 +219,11 @@ interface ColumnSchemaInterface
      * @see type()
      */
     public function getType(): string;
+
+    /**
+     * @return bool True if the datetime type has a timezone, false otherwise.
+     */
+    public function hasTimezone(): bool;
 
     /**
      * Whether this column is nullable.

--- a/src/Schema/SchemaInterface.php
+++ b/src/Schema/SchemaInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Db\Schema;
 
+use DateTimeInterface;
 use Throwable;
 use Yiisoft\Db\Command\DataType;
 use Yiisoft\Db\Constraint\ConstraintSchemaInterface;
@@ -247,6 +248,10 @@ interface SchemaInterface extends ConstraintSchemaInterface
      * Define the php type as `array` for cast to php value.
      */
     public const PHP_TYPE_ARRAY = 'array';
+    /**
+     * Define the php type as `DateTimeInterface` for cast to php value.
+     */
+    public const PHP_TYPE_DATE_TIME = DateTimeInterface::class;
     /**
      * Define the php type as `null` for cast to php value.
      */

--- a/tests/Common/CommonSchemaTest.php
+++ b/tests/Common/CommonSchemaTest.php
@@ -885,9 +885,9 @@ abstract class CommonSchemaTest extends AbstractSchemaTest
                     $column->getDefaultValue(),
                     "defaultValue of column $name is expected to be an object but it is not."
                 );
-                $this->assertSame(
-                    (string) $expected['defaultValue'],
-                    (string) $column->getDefaultValue(),
+                $this->assertEquals(
+                    $expected['defaultValue'],
+                    $column->getDefaultValue(),
                     "defaultValue of column $name does not match."
                 );
             } else {
@@ -905,6 +905,14 @@ abstract class CommonSchemaTest extends AbstractSchemaTest
                     $expected['dimension'],
                     $column->getDimension(),
                     "dimension of column $name does not match"
+                );
+            }
+
+            if (isset($expected['dateTimeFormat'])) {
+                $this->assertSame(
+                    $expected['dateTimeFormat'],
+                    $column->getDateTimeFormat(),
+                    "dateTimeFormat of column $name does not match"
                 );
             }
         }


### PR DESCRIPTION
Some comments are left for review and will be removed after.

`ColumnSchema::dateTimeFormat()` and `ColumnSchema::$dateTimeFormat` can be removed, in this case it will be necessary to determine the format from `ColumnSchema` each time when casting values.

### Update 09.08.2023
`ColumnSchema::hasTimezone()` can be replaced with two new abstract types `SchemaInterface::TYPE_TIMESTAMPTZ` and `SchemaInterface::TYPE_TIMETZ`

Both options (remove methods) can be done without loss of performance if type casting will be optimized as here [#737](https://github.com/yiisoft/db/issues/737)

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | #725