### PR TITLE
Different tables in columns

### DIFF
--- a/tests/Provider/QueryBuilderProvider.php
+++ b/tests/Provider/QueryBuilderProvider.php
@@ -213,6 +213,18 @@ class QueryBuilderProvider
                 ),
                 [':qp0' => null],
             ],
+            'different tables in columns' => [
+                '{{%type}}',
+                ['{{%type}}.[[bool_col]]', '{{%another_table}}.[[bool_col2]]'],
+                [[true, false]],
+                'expected' => DbHelper::replaceQuotes(
+                    <<<SQL
+                    INSERT INTO {{%type}} ([[bool_col]], [[bool_col2]]) VALUES (:qp0, :qp1)
+                    SQL,
+                    static::$driverName,
+                ),
+                [':qp0' => null, ':qp1' => null],
+            ],
             'empty-sql' => [
                 '{{%type}}',
                 [],


### PR DESCRIPTION
What is the correct behavior?
1. Filter columns from other tables
2. Let them be in the query

The test example is about the code:
```php
$table = '{{%type}}';
$columns = ['{{%type}}.[[bool_col]]', '{{%another_table}}.[[bool_col2]]'];
$values = [[true, false]];

$command->batchInsert($table, $columns, $values);

// INSERT INTO {{%type}} ([[bool_col]], [[bool_col2]]) VALUES (:qp0, :qp1)
```

The same for methods `batchInsert()`, `insert()`, `update()`, `upsert()`