### PR TITLE
Refactor `Quoter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## 1.1.2 under development
 
 - Bug #751: Fix collected debug actions (@xepozz)
-- Enh #756: Refactor Quoter (@Tigrov) 
-- Bug #756: Fix `quoteSql()` for sql containing table with prefix (@Tigrov)
+- Enh #756: Refactor `Quoter` (@Tigrov) 
+- Bug #756: Fix `quoteSql()` for SQL containing table with prefix (@Tigrov)
 - Bug #756: Fix `getTableNameParts()` for cases when different quotes for tables and columns (@Tigrov)
 - Bug #756: Fix `quoteTableName()` for sub-query with alias (@Tigrov)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## 1.1.2 under development
 
 - Bug #751: Fix collected debug actions (@xepozz)
+- Enh #756: Refactor Quoter (@Tigrov) 
+- Bug #756: Fix `quoteSql()` for sql containing table with prefix (@Tigrov)
+- Bug #756: Fix `getTableNameParts()` for cases when different quotes for tables and columns (@Tigrov)
+- Bug #756: Fix `quoteTableName()` for sub-query with alias (@Tigrov)
 
 ## 1.1.1 August 16, 2023
 

--- a/src/Schema/Quoter.php
+++ b/src/Schema/Quoter.php
@@ -175,7 +175,7 @@ class Quoter implements QuoterInterface
 
     public function quoteTableName(string $name): string
     {
-        if (str_starts_with($name, '(') && str_ends_with($name, ')')) {
+        if (str_starts_with($name, '(')) {
             return $name;
         }
 

--- a/src/Schema/Quoter.php
+++ b/src/Schema/Quoter.php
@@ -17,7 +17,6 @@ use function preg_match;
 use function preg_replace;
 use function preg_replace_callback;
 use function str_contains;
-use function str_ends_with;
 use function str_replace;
 use function str_starts_with;
 use function strrpos;

--- a/tests/Db/Schema/QuoterTest.php
+++ b/tests/Db/Schema/QuoterTest.php
@@ -105,7 +105,7 @@ final class QuoterTest extends AbstractQuoterTest
 
     public function testQuoteTableNameWithQueryAlias()
     {
-        $quoter = new Quoter('`', '`', 'prefix_');
+        $quoter = new Quoter('`', '`');
         $name = '(SELECT * FROM table) alias';
 
         $this->assertSame($name, $quoter->quoteTableName($name));

--- a/tests/Db/Schema/QuoterTest.php
+++ b/tests/Db/Schema/QuoterTest.php
@@ -102,4 +102,12 @@ final class QuoterTest extends AbstractQuoterTest
 
         $this->assertSame('SELECT * FROM `prefix_table`', $quoter->quoteSql($sql));
     }
+
+    public function testQuoteTableNameWithQueryAlias()
+    {
+        $quoter = new Quoter('`', '`', 'prefix_');
+        $name = '(SELECT * FROM table) alias';
+
+        $this->assertSame($name, $quoter->quoteTableName($name));
+    }
 }

--- a/tests/Db/Schema/QuoterTest.php
+++ b/tests/Db/Schema/QuoterTest.php
@@ -87,4 +87,19 @@ final class QuoterTest extends AbstractQuoterTest
             ['tableAlias' => 123],
         );
     }
+
+    public function testGetTableNamePartsWithDifferentQuotes(): void
+    {
+        $quoter = new Quoter('`', '"');
+
+        $this->assertSame(['schema', 'table'], $quoter->getTableNameParts('"schema"."table"'));
+    }
+
+    public function testQuoteSqlWithTablePrefix(): void
+    {
+        $quoter = new Quoter('`', '`', 'prefix_');
+        $sql = 'SELECT * FROM {{%table%}}';
+
+        $this->assertSame('SELECT * FROM `prefix_table`', $quoter->quoteSql($sql));
+    }
 }


### PR DESCRIPTION
1. Added used function to `use function` block
2. Replaced `str_contains()` with `str_starts_with()`
3. Removed unnecessary chars from patterns of regular expression
4. Fixed bug of `quoteSql()` for sql containing table with prefix ([test](https://github.com/yiisoft/db/pull/756/files#diff-de323c8909d597344bdb19b9c5c9391c60b65ce9db9313642b76736deceb6aaaR98-R105))
5. Fixed bug of `getTableNameParts()` for cases with different quotes for tables and columns ([test](https://github.com/yiisoft/db/pull/756/files#diff-de323c8909d597344bdb19b9c5c9391c60b65ce9db9313642b76736deceb6aaaR91-R96))
6. Fixed bug of `quoteTableName()` for sub-query with alias ([test](https://github.com/yiisoft/db/pull/756/files#diff-de323c8909d597344bdb19b9c5c9391c60b65ce9db9313642b76736deceb6aaaR106-R112))

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -
