### PR TITLE
Fix CTE query expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Bug #756: Fix `Quoter::quoteSql()` for SQL containing table with prefix (@Tigrov)
 - Bug #756: Fix `Quoter::getTableNameParts()` for cases when different quotes for tables and columns (@Tigrov)
 - Bug #756: Fix `Quoter::quoteTableName()` for sub-query with alias (@Tigrov)
+- Bug #761: Quote aliases of CTE in `WITH` queries (@Tigrov)
 
 ## 1.1.1 August 16, 2023
 

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -662,7 +662,7 @@ class Query implements QueryInterface
         return $this;
     }
 
-    public function withQuery(QueryInterface|string $query, string $alias, bool $recursive = false): static
+    public function withQuery(QueryInterface|string $query, ExpressionInterface|string $alias, bool $recursive = false): static
     {
         $this->withQueries[] = ['query' => $query, 'alias' => $alias, 'recursive' => $recursive];
         return $this;

--- a/src/Query/QueryPartsInterface.php
+++ b/src/Query/QueryPartsInterface.php
@@ -645,10 +645,11 @@ interface QueryPartsInterface
      * Prepends an SQL statement using `WITH` syntax.
      *
      * @param QueryInterface|string $query The SQL statement to append using `UNION`.
-     * @param string $alias The query alias in `WITH` construction.
+     * @param ExpressionInterface|string $alias The query alias in `WITH` construction.
+     * To specify the alias in plain SQL, you may pass an instance of {@see ExpressionInterface}.
      * @param bool $recursive Its `true` if using `WITH RECURSIVE` and `false` if using `WITH`.
      */
-    public function withQuery(QueryInterface|string $query, string $alias, bool $recursive = false): static;
+    public function withQuery(QueryInterface|string $query, ExpressionInterface|string $alias, bool $recursive = false): static;
 
     /**
      * Specifies the `WITH` query clause for the query.

--- a/src/QueryBuilder/AbstractDQLQueryBuilder.php
+++ b/src/QueryBuilder/AbstractDQLQueryBuilder.php
@@ -411,7 +411,7 @@ abstract class AbstractDQLQueryBuilder implements DQLQueryBuilderInterface
         $recursive = false;
         $result = [];
 
-        /** @psalm-var array<array-key, array{query:string|Query, alias:string, recursive:bool}> $withs */
+        /** @psalm-var array{query:string|Query, alias:ExpressionInterface|string, recursive:bool}[] $withs */
         foreach ($withs as $with) {
             if ($with['recursive']) {
                 $recursive = true;

--- a/tests/AbstractQueryBuilderTest.php
+++ b/tests/AbstractQueryBuilderTest.php
@@ -1183,9 +1183,14 @@ abstract class AbstractQueryBuilderTest extends TestCase
 
         [$sql, $params] = $qb->build($query);
 
-        $expected = DbHelper::replaceQuotes($expected, $db->getDriverName());
+        $expectedSql = DbHelper::replaceQuotes(
+            <<<SQL
+            WITH $expected AS (SELECT * FROM [[t]]) SELECT * FROM [[t]]
+            SQL,
+            $db->getDriverName(),
+        );
 
-        $this->assertSame($expected, $sql);
+        $this->assertSame($expectedSql, $sql);
         $this->assertSame([], $params);
     }
 

--- a/tests/Common/CommonQueryTest.php
+++ b/tests/Common/CommonQueryTest.php
@@ -38,7 +38,7 @@ abstract class CommonQueryTest extends AbstractQueryTest
 
     public function testWithQuery()
     {
-        $db = $this->getConnection();
+        $db = $this->getConnection(true);
 
         $with = (new Query($db))
             ->distinct()
@@ -50,6 +50,8 @@ abstract class CommonQueryTest extends AbstractQueryTest
             ->from('statuses');
 
         $this->assertEquals(2, $query->count());
+
+        $db->close();
     }
 
     public function testWithQueryRecursive()
@@ -76,5 +78,7 @@ abstract class CommonQueryTest extends AbstractQueryTest
             ->sum($quotedName);
 
         $this->assertEquals(55, $sum);
+
+        $db->close();
     }
 }

--- a/tests/Common/CommonQueryTest.php
+++ b/tests/Common/CommonQueryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Db\Tests\Common;
 
+use Yiisoft\Db\Expression\Expression;
 use Yiisoft\Db\Query\Query;
 use Yiisoft\Db\Tests\AbstractQueryTest;
 
@@ -33,5 +34,47 @@ abstract class CommonQueryTest extends AbstractQueryTest
         $this->assertEquals([2 => '1', 4 => '2', 6 => '3'], $result);
 
         $db->close();
+    }
+
+    public function testWithQuery()
+    {
+        $db = $this->getConnection();
+
+        $with = (new Query($db))
+            ->distinct()
+            ->select(['status'])
+            ->from('customer');
+
+        $query = (new Query($db))
+            ->withQuery($with, 'statuses')
+            ->from('statuses');
+
+        $this->assertEquals(2, $query->count());
+    }
+
+    public function testWithQueryRecursive()
+    {
+        $db = $this->getConnection();
+        $quoter = $db->getQuoter();
+        $isOracle = $db->getDriverName() === 'oci';
+
+        /** Sum 1 to 10 equals 55 */
+        $quotedName = $quoter->quoteColumnName('n');
+        $union = (new Query($db))
+            ->select(new Expression($quotedName . ' + 1'))
+            ->from('t')
+            ->where(['<', 'n', 10]);
+
+        $with = (new Query($db))
+            ->select(new Expression('1'))
+            ->from($isOracle ? new Expression('DUAL') : [])
+            ->union($union, true);
+
+        $sum = (new Query($db))
+            ->withQuery($with, 't(n)', true)
+            ->from('t')
+            ->sum($quotedName);
+
+        $this->assertEquals(55, $sum);
     }
 }

--- a/tests/Provider/QueryBuilderProvider.php
+++ b/tests/Provider/QueryBuilderProvider.php
@@ -1235,36 +1235,11 @@ class QueryBuilderProvider
     public static function cteAliases(): array
     {
         return [
-            'simple' => [
-                'a',
-                <<<SQL
-                WITH [[a]] AS (SELECT * FROM [[t]]) SELECT * FROM [[t]]
-                SQL,
-            ],
-            'with one column' => [
-                'a(b)',
-                <<<SQL
-                WITH [[a]]([[b]]) AS (SELECT * FROM [[t]]) SELECT * FROM [[t]]
-                SQL,
-            ],
-            'with columns' => [
-                'a(b,c,d)',
-                <<<SQL
-                WITH [[a]]([[b]], [[c]], [[d]]) AS (SELECT * FROM [[t]]) SELECT * FROM [[t]]
-                SQL,
-            ],
-            'with extra space' => [
-                'a(b,c,d) ',
-                <<<SQL
-                WITH a(b,c,d)  AS (SELECT * FROM [[t]]) SELECT * FROM [[t]]
-                SQL,
-            ],
-            'expression' => [
-                new Expression('a(b,c,d)'),
-                <<<SQL
-                WITH a(b,c,d) AS (SELECT * FROM [[t]]) SELECT * FROM [[t]]
-                SQL,
-            ],
+            'simple' => ['a', '[[a]]'],
+            'with one column' => ['a(b)', '[[a]]([[b]])'],
+            'with columns' => ['a(b,c,d)', '[[a]]([[b]], [[c]], [[d]])'],
+            'with extra space' => ['a(b,c,d) ', 'a(b,c,d) '],
+            'expression' => [new Expression('a(b,c,d)'), 'a(b,c,d)'],
         ];
     }
 }

--- a/tests/Provider/QueryBuilderProvider.php
+++ b/tests/Provider/QueryBuilderProvider.php
@@ -1231,4 +1231,40 @@ class QueryBuilderProvider
             ],
         ];
     }
+
+    public static function cteAliases(): array
+    {
+        return [
+            'simple' => [
+                'a',
+                <<<SQL
+                WITH [[a]] AS (SELECT * FROM [[t]]) SELECT * FROM [[t]]
+                SQL,
+            ],
+            'with one column' => [
+                'a(b)',
+                <<<SQL
+                WITH [[a]]([[b]]) AS (SELECT * FROM [[t]]) SELECT * FROM [[t]]
+                SQL,
+            ],
+            'with columns' => [
+                'a(b,c,d)',
+                <<<SQL
+                WITH [[a]]([[b]], [[c]], [[d]]) AS (SELECT * FROM [[t]]) SELECT * FROM [[t]]
+                SQL,
+            ],
+            'with extra space' => [
+                'a(b,c,d) ',
+                <<<SQL
+                WITH a(b,c,d)  AS (SELECT * FROM [[t]]) SELECT * FROM [[t]]
+                SQL,
+            ],
+            'expression' => [
+                new Expression('a(b,c,d)'),
+                <<<SQL
+                WITH a(b,c,d) AS (SELECT * FROM [[t]]) SELECT * FROM [[t]]
+                SQL,
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
1. Fix bug with Oracle when CTE aliases is not quoted.
2. Fix bug with Oracle and MSSQL: `RECURSIVE` expression is not needed for CTE.

### Related PRs ###
* yiisoft/db-mssql#278
* yiisoft/db-oracle#240
* yiisoft/db-sqlite#274
* yiisoft/db-mysql#305

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -