### PR TITLE
Deprecate abstract type `SchemaInterface::TYPE_JSONB`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Bug #756: Fix `Quoter::quoteSql()` for SQL containing table with prefix (@Tigrov)
 - Bug #756: Fix `Quoter::getTableNameParts()` for cases when different quotes for tables and columns (@Tigrov)
 - Bug #756: Fix `Quoter::quoteTableName()` for sub-query with alias (@Tigrov)
+- Chg #765: Deprecate `SchemaInterface::TYPE_JSONB` (@Tigrov)
 
 ## 1.1.1 August 16, 2023
 

--- a/src/Schema/SchemaInterface.php
+++ b/src/Schema/SchemaInterface.php
@@ -220,6 +220,8 @@ interface SchemaInterface extends ConstraintSchemaInterface
     public const TYPE_JSON = 'json';
     /**
      * Define the abstract column type as `jsonb`.
+     *
+     * @deprecated will be removed in version 2.0.0. Use `SchemaInterface::TYPE_JSON` instead.
      */
     public const TYPE_JSONB = 'jsonb';
 


### PR DESCRIPTION
`jsonb` is an incorrect abstract type. It is a specific `json` type of PorstgeSQL

See comment https://github.com/yiisoft/db/pull/723#discussion_r1254457912

**Repated PR:** yiisoft/db-pgsql#319

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -
