### PR TITLE
Deprecate unnecessary argument `$rawSql` of `AbstractCommand::internalExecute()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 1.2.1 under development
 
-- Bug #777: Fix `Query::count()` when it returns an incorrect value if the result is greater
-  than `PHP_INT_MAX` (@Tigrov)
+- Bug #777: Fix `Query::count()` when it returns an incorrect value if the result is greater than `PHP_INT_MAX` (@Tigrov)
+- Enh #778: Deprecate unnecessary argument `$rawSql` of `AbstractCommand::internalExecute()` (@Tigrov)
 
 ## 1.2.0 November 12, 2023
 

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -548,7 +548,7 @@ abstract class AbstractCommand implements CommandInterface
     /**
      * Executes a prepared statement.
      *
-     * @param string|null $rawSql The rawSql if it has been created.
+     * @param string|null $rawSql Deprecated. Use `null` value. Will be removed in version 2.0.0.
      *
      * @throws Exception
      * @throws Throwable
@@ -581,7 +581,7 @@ abstract class AbstractCommand implements CommandInterface
         $isReadMode = $this->isReadMode($queryMode);
         $this->prepare($isReadMode);
 
-        $this->internalExecute($this->getRawSql());
+        $this->internalExecute(null);
 
         /** @psalm-var mixed $result */
         $result = $this->internalGetQueryResult($queryMode);

--- a/src/Driver/Pdo/AbstractPdoCommand.php
+++ b/src/Driver/Pdo/AbstractPdoCommand.php
@@ -186,7 +186,7 @@ abstract class AbstractPdoCommand extends AbstractCommand implements PdoCommandI
      *
      * It's a wrapper around {@see PDOStatement::execute()} to support transactions and retry handlers.
      *
-     * @param string|null $rawSql The rawSql if it has been created.
+     * @param string|null $rawSql Deprecated. Use `null` value. Will be removed in version 2.0.0.
      *
      * @throws Exception
      * @throws Throwable


### PR DESCRIPTION
The optimization also removes extra call `$this->getRawSql()`.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -