### PR TITLE
Do not call `CommandInterface::getRawSql()` if no `logger` or `profiler`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   `DbArrayHelper::populate()` methods to `array[]` (@vjik)
 - Enh #779: Specify populate closure type in `BatchQueryResultInterface` (@vjik)
 - Enh #778: Deprecate unnecessary argument `$rawSql` of `AbstractCommand::internalExecute()` (@Tigrov)
-- Enh #781: Do not call `CommandInterface::getRawSql()` if no `logger` or `profiler` is set (@Tigrov)
+- Enh #781: Skip calling `CommandInterface::getRawSql()` if no `logger` or `profiler` is set (@Tigrov)
 
 ## 1.2.0 November 12, 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   `DbArrayHelper::populate()` methods to `array[]` (@vjik)
 - Enh #779: Specify populate closure type in `BatchQueryResultInterface` (@vjik)
 - Enh #778: Deprecate unnecessary argument `$rawSql` of `AbstractCommand::internalExecute()` (@Tigrov)
+- Enh #781: Do not call `CommandInterface::getRawSql()` if no `logger` or `profiler` is set (@Tigrov)
 
 ## 1.2.0 November 12, 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Enh #779: Specify populate closure type in `BatchQueryResultInterface` (@vjik)
 - Enh #778: Deprecate unnecessary argument `$rawSql` of `AbstractCommand::internalExecute()` (@Tigrov)
 - Enh #781: Skip calling `CommandInterface::getRawSql()` if no `logger` or `profiler` is set (@Tigrov)
+- Enh #781: Deprecate `AbstractCommand::logQuery()` method (@Tigrov)
 
 ## 1.2.0 November 12, 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
 - Enh #779: Specify populate closure type in `BatchQueryResultInterface` (@vjik)
 - Enh #778: Deprecate unnecessary argument `$rawSql` of `AbstractCommand::internalExecute()` (@Tigrov)
 - Enh #781: Skip calling `CommandInterface::getRawSql()` if no `logger` or `profiler` is set (@Tigrov)
-- Enh #781: Deprecate `AbstractCommand::logQuery()` method (@Tigrov)
 - Enh #785: Refactor `AbstractCommand::getRawSql()` (@Tigrov)
 - Bug #785: Fix bug of `AbstractCommand::getRawSql()` when a param value is `Stringable` object (@Tigrov)
 - Enh #786: Refactor `AbstractSchema::getDataType()` (@Tigrov)

--- a/src/Driver/Pdo/AbstractPdoCommand.php
+++ b/src/Driver/Pdo/AbstractPdoCommand.php
@@ -257,8 +257,6 @@ abstract class AbstractPdoCommand extends AbstractCommand implements PdoCommandI
 
     /**
      * Logs the current database query if query logging is on and returns the profiling token if profiling is on.
-     *
-     * @deprecated Use {@see logger} instead. Will be removed in version 2.0.0.
      */
     protected function logQuery(string $rawSql, string $category): void
     {
@@ -269,7 +267,10 @@ abstract class AbstractPdoCommand extends AbstractCommand implements PdoCommandI
     {
         $logCategory = self::class . '::' . $this->getQueryMode($queryMode);
 
-        $this->logger?->info($rawSql = $this->getRawSql(), [$logCategory]);
+        if ($this->logger !== null) {
+            $rawSql = $this->getRawSql();
+            $this->logQuery($rawSql, $logCategory);
+        }
 
         $queryContext = new CommandContext(__METHOD__, $logCategory, $this->getSql(), $this->getParams());
 

--- a/src/Driver/Pdo/AbstractPdoCommand.php
+++ b/src/Driver/Pdo/AbstractPdoCommand.php
@@ -257,6 +257,8 @@ abstract class AbstractPdoCommand extends AbstractCommand implements PdoCommandI
 
     /**
      * Logs the current database query if query logging is on and returns the profiling token if profiling is on.
+     *
+     * @deprecated Use {@see logger} instead. Will be removed in version 2.0.0.
      */
     protected function logQuery(string $rawSql, string $category): void
     {
@@ -267,7 +269,7 @@ abstract class AbstractPdoCommand extends AbstractCommand implements PdoCommandI
     {
         $logCategory = self::class . '::' . $this->getQueryMode($queryMode);
 
-        $this->logger?->log(LogLevel::INFO, $rawSql = $this->getRawSql(), [$logCategory]);
+        $this->logger?->info($rawSql = $this->getRawSql(), [$logCategory]);
 
         $queryContext = new CommandContext(__METHOD__, $logCategory, $this->getSql(), $this->getParams());
 

--- a/src/Driver/Pdo/AbstractPdoCommand.php
+++ b/src/Driver/Pdo/AbstractPdoCommand.php
@@ -265,7 +265,12 @@ abstract class AbstractPdoCommand extends AbstractCommand implements PdoCommandI
 
     protected function queryInternal(int $queryMode): mixed
     {
-        $rawSql = $this->getRawSql();
+        $rawSql = '';
+
+        if ($this->logger !== null || $this->profiler !== null) {
+            $rawSql = $this->getRawSql();
+        }
+
         $logCategory = self::class . '::' . $this->getQueryMode($queryMode);
 
         $this->logQuery($rawSql, $logCategory);

--- a/src/Driver/Pdo/AbstractPdoCommand.php
+++ b/src/Driver/Pdo/AbstractPdoCommand.php
@@ -265,19 +265,18 @@ abstract class AbstractPdoCommand extends AbstractCommand implements PdoCommandI
 
     protected function queryInternal(int $queryMode): mixed
     {
-        $rawSql = '';
-
-        if ($this->logger !== null || $this->profiler !== null) {
-            $rawSql = $this->getRawSql();
-        }
-
         $logCategory = self::class . '::' . $this->getQueryMode($queryMode);
 
-        $this->logQuery($rawSql, $logCategory);
+        $this->logger?->log(LogLevel::INFO, $rawSql = $this->getRawSql(), [$logCategory]);
 
         $queryContext = new CommandContext(__METHOD__, $logCategory, $this->getSql(), $this->getParams());
 
-        $this->profiler?->begin($rawSql, $queryContext);
+        /**
+         * @psalm-var string $rawSql
+         * @psalm-suppress RedundantConditionGivenDocblockType
+         * @psalm-suppress DocblockTypeContradiction
+         */
+        $this->profiler?->begin($rawSql ??= $this->getRawSql(), $queryContext);
         try {
             /** @psalm-var mixed $result */
             $result = parent::queryInternal($queryMode);

--- a/tests/Common/CommonPdoCommandTest.php
+++ b/tests/Common/CommonPdoCommandTest.php
@@ -235,9 +235,8 @@ abstract class CommonPdoCommandTest extends TestCase
         $logger = $this->createMock(LoggerInterface::class);
         $logger
             ->expects($this->once())
-            ->method('log')
+            ->method('info')
             ->with(
-                LogLevel::INFO,
                 $sql,
                 $params
             );

--- a/tests/Common/CommonPdoCommandTest.php
+++ b/tests/Common/CommonPdoCommandTest.php
@@ -7,6 +7,7 @@ namespace Yiisoft\Db\Tests\Common;
 use PDO;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 use Yiisoft\Db\Command\Param;
 use Yiisoft\Db\Command\ParamInterface;
 use Yiisoft\Db\Driver\Pdo\AbstractPdoCommand;
@@ -234,8 +235,9 @@ abstract class CommonPdoCommandTest extends TestCase
         $logger = $this->createMock(LoggerInterface::class);
         $logger
             ->expects($this->once())
-            ->method('info')
+            ->method('log')
             ->with(
+                LogLevel::INFO,
                 $sql,
                 $params
             );

--- a/tests/Common/CommonPdoCommandTest.php
+++ b/tests/Common/CommonPdoCommandTest.php
@@ -7,7 +7,6 @@ namespace Yiisoft\Db\Tests\Common;
 use PDO;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
-use Psr\Log\LogLevel;
 use Yiisoft\Db\Command\Param;
 use Yiisoft\Db\Command\ParamInterface;
 use Yiisoft\Db\Driver\Pdo\AbstractPdoCommand;


### PR DESCRIPTION
Optimization

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -
