### PR TITLE
Specify result type of `ConstraintSchemaInterface::getTableIndexes()` method to `IndexConstraint[]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   `DbArrayHelper::populate()` methods to `array[]` (@vjik)
 - Enh #779: Specify populate closure type in `BatchQueryResultInterface` (@vjik)
 - Enh #778: Deprecate unnecessary argument `$rawSql` of `AbstractCommand::internalExecute()` (@Tigrov)
+- Enh #784: Specify result type of `ConstraintSchemaInterface::getTableIndexes()` method to `IndexConstraint[]` (@vjik)
 
 ## 1.2.0 November 12, 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Enh #779: Specify populate closure type in `BatchQueryResultInterface` (@vjik)
 - Enh #778: Deprecate unnecessary argument `$rawSql` of `AbstractCommand::internalExecute()` (@Tigrov)
 - Enh #784: Specify result type of `ConstraintSchemaInterface::getTableIndexes()` method to `IndexConstraint[]` (@vjik)
+- Enh #784: Remove unused code in `AbstractSchema::getTableIndexes()` (@vjik)
 
 ## 1.2.0 November 12, 2023
 

--- a/src/Constraint/ConstraintSchemaInterface.php
+++ b/src/Constraint/ConstraintSchemaInterface.php
@@ -131,7 +131,7 @@ interface ConstraintSchemaInterface
      * @param string $name Table name. The table name may contain a schema name if any. Don't quote the table name.
      * @param bool $refresh Whether to reload the information, even if it's found in the cache.
      *
-     * @return array The information metadata for the indexes of the named table.
+     * @return IndexConstraint[] The information metadata for the indexes of the named table.
      */
     public function getTableIndexes(string $name, bool $refresh = false): array;
 

--- a/src/QueryBuilder/AbstractDMLQueryBuilder.php
+++ b/src/QueryBuilder/AbstractDMLQueryBuilder.php
@@ -6,7 +6,6 @@ namespace Yiisoft\Db\QueryBuilder;
 
 use JsonException;
 use Yiisoft\Db\Constraint\Constraint;
-use Yiisoft\Db\Constraint\IndexConstraint;
 use Yiisoft\Db\Exception\Exception;
 use Yiisoft\Db\Exception\InvalidArgumentException;
 use Yiisoft\Db\Exception\InvalidConfigException;
@@ -335,7 +334,6 @@ abstract class AbstractDMLQueryBuilder implements DMLQueryBuilderInterface
             $constraints[] = $primaryKey;
         }
 
-        /** @psalm-var IndexConstraint[] $tableIndexes */
         $tableIndexes = $this->schema->getTableIndexes($name);
 
         foreach ($tableIndexes as $constraint) {

--- a/src/Schema/AbstractSchema.php
+++ b/src/Schema/AbstractSchema.php
@@ -10,6 +10,7 @@ use Yiisoft\Db\Cache\SchemaCache;
 use Yiisoft\Db\Command\DataType;
 use Yiisoft\Db\Connection\ConnectionInterface;
 use Yiisoft\Db\Constraint\Constraint;
+use Yiisoft\Db\Constraint\IndexConstraint;
 use Yiisoft\Db\Exception\NotSupportedException;
 
 use function array_change_key_case;
@@ -95,7 +96,7 @@ abstract class AbstractSchema implements SchemaInterface
      *
      * @param string $tableName The table name.
      *
-     * @return array The indexes for the given table.
+     * @return IndexConstraint[] The indexes for the given table.
      */
     abstract protected function loadTableIndexes(string $tableName): array;
 
@@ -261,7 +262,7 @@ abstract class AbstractSchema implements SchemaInterface
      */
     public function getTableIndexes(string $name, bool $refresh = false): array
     {
-        /** @psalm-var mixed $tableIndexes */
+        /** @var IndexConstraint[]|null $tableIndexes */
         $tableIndexes = $this->getTableMetadata($name, SchemaInterface::INDEXES, $refresh);
         return is_array($tableIndexes) ? $tableIndexes : [];
     }

--- a/src/Schema/AbstractSchema.php
+++ b/src/Schema/AbstractSchema.php
@@ -262,9 +262,8 @@ abstract class AbstractSchema implements SchemaInterface
      */
     public function getTableIndexes(string $name, bool $refresh = false): array
     {
-        /** @var IndexConstraint[]|null $tableIndexes */
-        $tableIndexes = $this->getTableMetadata($name, SchemaInterface::INDEXES, $refresh);
-        return is_array($tableIndexes) ? $tableIndexes : [];
+        /** @var IndexConstraint[] */
+        return $this->getTableMetadata($name, SchemaInterface::INDEXES, $refresh);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -