### PR TITLE
Test `Command::insertWithReturningPks()` with empty values

### DIFF
--- a/tests/Common/CommonCommandTest.php
+++ b/tests/Common/CommonCommandTest.php
@@ -2015,4 +2015,15 @@ abstract class CommonCommandTest extends AbstractCommandTest
 
         $this->assertSame($decimalValue, $phpTypecastValue);
     }
+
+    public function testInsertWithReturningPksEmptyValues()
+    {
+        $db = $this->getConnection(true);
+
+        $pkValues = $db->createCommand()->insertWithReturningPks('null_values', []);
+
+        $this->assertSame(['id' => 1], $pkValues);
+
+        $db->createCommand()->dropTable('null_values')->execute();
+    }
 }

--- a/tests/Common/CommonCommandTest.php
+++ b/tests/Common/CommonCommandTest.php
@@ -2029,4 +2029,13 @@ abstract class CommonCommandTest extends AbstractCommandTest
 
         $this->assertSame($expected, $pkValues);
     }
+
+    public function testInsertWithReturningPksEmptyValuesAndNoPk()
+    {
+        $db = $this->getConnection(true);
+
+        $pkValues = $db->createCommand()->insertWithReturningPks('negative_default_values', []);
+
+        $this->assertSame([], $pkValues);
+    }
 }

--- a/tests/Common/CommonCommandTest.php
+++ b/tests/Common/CommonCommandTest.php
@@ -2022,7 +2022,12 @@ abstract class CommonCommandTest extends AbstractCommandTest
 
         $pkValues = $db->createCommand()->insertWithReturningPks('null_values', []);
 
-        $this->assertSame(['id' => 1], $pkValues);
+        $expected = match ($db->getDriverName()) {
+            'pgsql' => ['id' => 1],
+            default => ['id' => '1'],
+        };
+
+        $this->assertSame($expected, $pkValues);
 
         $db->createCommand()->dropTable('null_values')->execute();
     }

--- a/tests/Common/CommonCommandTest.php
+++ b/tests/Common/CommonCommandTest.php
@@ -2028,7 +2028,5 @@ abstract class CommonCommandTest extends AbstractCommandTest
         };
 
         $this->assertSame($expected, $pkValues);
-
-        $db->createCommand()->dropTable('null_values')->execute();
     }
 }


### PR DESCRIPTION
### Related PRs:

* yiisoft/db-mssql#287
* yiisoft/db-oracle#250
* yiisoft/db-mysql#314

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #792
