### PR TITLE
Rename `batchInsert()` to `insertBatch()` and change paremeters order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Enh #806: Build `Expression` instances inside `Expression::$params` when build a query using `QueryBuilder` (@Tigrov)
 - Enh #766: Allow `ColumnInterface` as column type. (@Tigrov)
 - Bug #828: Fix `float` type when use `AbstractCommand::getRawSql()` method (@Tigrov)
+- Enh #829: Rename `batchInsert()` to `insertBatch()` in `DMLQueryBuilderInterface` and `CommandInterface`
+  and change parameters order from `$table, $columns, $rows` to `$table, $rows, $columns = []` (@Tigrov)
 
 ## 1.3.0 March 21, 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Enh #766: Allow `ColumnInterface` as column type. (@Tigrov)
 - Bug #828: Fix `float` type when use `AbstractCommand::getRawSql()` method (@Tigrov)
 - Enh #829: Rename `batchInsert()` to `insertBatch()` in `DMLQueryBuilderInterface` and `CommandInterface`
-  and change parameters order from `$table, $columns, $rows` to `$table, $rows, $columns = []` (@Tigrov)
+  and change parameters from `$table, $columns, $rows` to `$table, $rows, $columns = []` (@Tigrov)
 
 ## 1.3.0 March 21, 2024
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -35,3 +35,22 @@ Add support any scalar values for `$columns` parameter of these methods in your 
 `Expression::$params` can contain:
 - non-unique placeholder names, they will be replaced with unique names.
 - `Expression` instances, they will be built when building a query using `QueryBuilder`.
+
+### Rename `batchInsert()` to `insertBatch()`
+
+`batchInsert()` method is renamed to `insertBatch()` in `DMLQueryBuilderInterface` and `CommandInterface`.
+The parameters order is changed from `$table, $columns, $rows` to `$table, $rows, $columns = []`.
+It allows to use the method without columns, for example:
+
+```php
+use Yiisoft\Db\Connection\ConnectionInterface;
+
+$values = [
+    ['name' => 'Tom', 'age' => 30],
+    ['name' => 'Jane', 'age' => 20],
+    ['name' => 'Linda', 'age' => 25],
+];
+
+/** @var ConnectionInterface $db */
+$db->createCommand()->insertBatch('user', $values)->execute();
+```

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -39,7 +39,7 @@ Add support any scalar values for `$columns` parameter of these methods in your 
 ### Rename `batchInsert()` to `insertBatch()`
 
 `batchInsert()` method is renamed to `insertBatch()` in `DMLQueryBuilderInterface` and `CommandInterface`.
-The parameters order is changed from `$table, $columns, $rows` to `$table, $rows, $columns = []`.
+The parameters are changed from `$table, $columns, $rows` to `$table, $rows, $columns = []`.
 It allows to use the method without columns, for example:
 
 ```php

--- a/docs/guide/en/command/dml.md
+++ b/docs/guide/en/command/dml.md
@@ -13,20 +13,36 @@ You can use the DML to perform the following operations:
 
 ## Batch insert
 
-To insert multiple rows into a table, you can use the `Yiisoft\Db\Command\CommandInterface::batchInsert()` method:
+To insert multiple rows into a table, you can use the `Yiisoft\Db\Command\CommandInterface::insertBatch()` method:
 
 ```php
 use Yiisoft\Db\Connection\ConnectionInterface;
 
 /** @var ConnectionInterface $db */
-$db->createCommand()->batchInsert(
+$db->createCommand()->insertBatch(
     '{{%customer}}',
-    ['name', 'email'],
     [
         ['user1', 'email1@email.com'],
         ['user2', 'email2@email.com'],
         ['user3', 'email3@email.com'],
-    ]
+    ],
+    ['name', 'email'],
+)->execute();
+```
+
+It is possible to insert rows as associative arrays, where the keys are column names.
+
+```php
+use Yiisoft\Db\Connection\ConnectionInterface;
+
+/** @var ConnectionInterface $db */
+$db->createCommand()->insertBatch(
+    '{{%customer}}',
+    [
+        ['name' => 'user1', 'email' => 'email1@email.com'],
+        ['name' => 'user2', 'email' => 'email2@email.com'],
+        ['name' => 'user3', 'email' => 'email3@email.com'],
+    ],
 )->execute();
 ```
 

--- a/docs/guide/pt-BR/command/dml.md
+++ b/docs/guide/pt-BR/command/dml.md
@@ -13,13 +13,13 @@ Você pode usar o DML para realizar as seguintes operações:
 
 ## Inserção em lote
 
-Para inserir múltiplas linhas em uma tabela, você pode usar o método `Yiisoft\Db\Command\CommandInterface::batchInsert()`:
+Para inserir múltiplas linhas em uma tabela, você pode usar o método `Yiisoft\Db\Command\CommandInterface::insertBatch()`:
 
 ```php
 use Yiisoft\Db\Connection\ConnectionInterface;
 
 /** @var ConnectionInterface $db */
-$db->createCommand()->batchInsert(
+$db->createCommand()->insertBatch(
     '{{%customer}}',
     ['name', 'email'],
     [
@@ -27,6 +27,22 @@ $db->createCommand()->batchInsert(
         ['user2', 'email2@email.com'],
         ['user3', 'email3@email.com'],
     ]
+)->execute();
+```
+
+It is possible to insert rows as associative arrays, where the keys are column names.
+
+```php
+use Yiisoft\Db\Connection\ConnectionInterface;
+
+/** @var ConnectionInterface $db */
+$db->createCommand()->insertBatch(
+    '{{%customer}}',
+    [
+        ['name' => 'user1', 'email' => 'email1@email.com'],
+        ['name' => 'user2', 'email' => 'email2@email.com'],
+        ['name' => 'user3', 'email' => 'email3@email.com'],
+    ],
 )->execute();
 ```
 

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -10,6 +10,7 @@ use Yiisoft\Db\Exception\Exception;
 use Yiisoft\Db\Expression\Expression;
 use Yiisoft\Db\Query\Data\DataReaderInterface;
 use Yiisoft\Db\Query\QueryInterface;
+use Yiisoft\Db\QueryBuilder\DMLQueryBuilderInterface;
 use Yiisoft\Db\QueryBuilder\QueryBuilderInterface;
 use Yiisoft\Db\Schema\Builder\ColumnInterface;
 
@@ -63,6 +64,8 @@ use function stream_get_contents;
  * ```
  *
  * To build `SELECT` SQL statements, please use {@see QueryInterface} and its implementations instead.
+ *
+ * @psalm-import-type BatchValues from DMLQueryBuilderInterface
  */
 abstract class AbstractCommand implements CommandInterface
 {
@@ -193,7 +196,19 @@ abstract class AbstractCommand implements CommandInterface
         return $this->setSql($sql)->requireTableSchemaRefresh($table);
     }
 
+    /**
+     * @param string[] $columns
+     *
+     * @psalm-param BatchValues $rows
+     *
+     * @deprecated Use (@see insertBatch()) instead. It will be removed in version 3.0.0.
+     */
     public function batchInsert(string $table, array $columns, iterable $rows): static
+    {
+        return $this->insertBatch($table, $rows, $columns);
+    }
+
+    public function insertBatch(string $table, iterable $rows, array $columns = []): static
     {
         $table = $this->getQueryBuilder()->quoter()->quoteSql($table);
 
@@ -205,7 +220,7 @@ abstract class AbstractCommand implements CommandInterface
         unset($column);
 
         $params = [];
-        $sql = $this->getQueryBuilder()->batchInsert($table, $columns, $rows, $params);
+        $sql = $this->getQueryBuilder()->insertBatch($table, $rows, $columns, $params);
 
         $this->setRawSql($sql);
         $this->bindValues($params);

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -203,7 +203,7 @@ abstract class AbstractCommand implements CommandInterface
      *
      * @psalm-param BatchValues $rows
      *
-     * @deprecated Use (@see insertBatch()) instead. It will be removed in version 3.0.0.
+     * @deprecated Use {@see insertBatch()} instead. It will be removed in version 3.0.0.
      */
     public function batchInsert(string $table, array $columns, iterable $rows): static
     {

--- a/src/Command/CommandInterface.php
+++ b/src/Command/CommandInterface.php
@@ -15,6 +15,7 @@ use Yiisoft\Db\Exception\InvalidConfigException;
 use Yiisoft\Db\Exception\NotSupportedException;
 use Yiisoft\Db\Query\Data\DataReaderInterface;
 use Yiisoft\Db\Query\QueryInterface;
+use Yiisoft\Db\QueryBuilder\DMLQueryBuilderInterface;
 use Yiisoft\Db\Schema\Builder\ColumnInterface;
 
 /**
@@ -23,6 +24,7 @@ use Yiisoft\Db\Schema\Builder\ColumnInterface;
  * A command instance is usually created by calling {@see ConnectionInterface::createCommand}.
  *
  * @psalm-import-type ParamsType from ConnectionInterface
+ * @psalm-import-type BatchValues from DMLQueryBuilderInterface
  */
 interface CommandInterface
 {
@@ -156,13 +158,26 @@ interface CommandInterface
      * For example,
      *
      * ```php
-     * $connectionInterface->createCommand()->batchInsert(
+     * $connectionInterface->createCommand()->insertBatch(
      *     'user',
-     *     ['name', 'age'],
      *     [
      *         ['Tom', 30],
      *         ['Jane', 20],
      *         ['Linda', 25],
+     *     ],
+     *     ['name', 'age']
+     * )->execute();
+     * ```
+     *
+     * or as associative arrays where the keys are column names
+     *
+     * ```php
+     * $connectionInterface->createCommand()->insertBatch(
+     *     'user',
+     *     [
+     *         ['name' => 'Tom', 'age' => 30],
+     *         ['name' => 'Jane', 'age' => 20],
+     *         ['name' => 'Linda', 'age' => 25],
      *     ]
      * )->execute();
      * ```
@@ -174,17 +189,17 @@ interface CommandInterface
      * Also note that the created command isn't executed until {@see execute()} is called.
      *
      * @param string $table The name of the table to insert new rows into.
-     * @param array $columns The column names.
      * @param iterable $rows The rows to be batch inserted into the table.
+     * @param string[] $columns The column names.
      *
      * @throws Exception
      * @throws InvalidArgumentException
      *
-     * @psalm-param iterable<array-key, array<array-key, mixed>> $rows
+     * @psalm-param BatchValues $rows
      *
      * Note: The method will quote the `table` and `column` parameters before using them in the generated SQL.
      */
-    public function batchInsert(string $table, array $columns, iterable $rows): static;
+    public function insertBatch(string $table, iterable $rows, array $columns = []): static;
 
     /**
      * Binds a parameter to the SQL statement to be executed.

--- a/src/Debug/CommandInterfaceProxy.php
+++ b/src/Debug/CommandInterfaceProxy.php
@@ -101,7 +101,7 @@ final class CommandInterfaceProxy implements CommandInterface
     /**
      * @psalm-suppress  MixedArgument
      */
-    public function batchInsert(string $table, array $columns, iterable $rows): static
+    public function insertBatch(string $table, iterable $rows, array $columns = []): static
     {
         return new self($this->decorated->{__FUNCTION__}(...func_get_args()), $this->collector);
     }

--- a/src/QueryBuilder/AbstractDMLQueryBuilder.php
+++ b/src/QueryBuilder/AbstractDMLQueryBuilder.php
@@ -32,10 +32,10 @@ use function array_unique;
 use function array_values;
 use function count;
 use function get_object_vars;
+use function gettype;
 use function implode;
 use function in_array;
 use function is_array;
-use function is_object;
 use function is_string;
 use function iterator_to_array;
 use function json_encode;
@@ -52,6 +52,7 @@ use function sort;
  * @link https://en.wikipedia.org/wiki/Data_manipulation_language
  *
  * @psalm-import-type ParamsType from ConnectionInterface
+ * @psalm-import-type BatchValues from DMLQueryBuilderInterface
  */
 abstract class AbstractDMLQueryBuilder implements DMLQueryBuilderInterface
 {
@@ -62,7 +63,20 @@ abstract class AbstractDMLQueryBuilder implements DMLQueryBuilderInterface
     ) {
     }
 
+    /**
+     * @param string[] $columns
+     *
+     * @psalm-param BatchValues $rows
+     * @psalm-param ParamsType $params
+     *
+     * @deprecated Use (@see insertBatch()) instead. It will be removed in version 3.0.0.
+     */
     public function batchInsert(string $table, array $columns, iterable $rows, array &$params = []): string
+    {
+        return $this->insertBatch($table, $rows, $columns, $params);
+    }
+
+    public function insertBatch(string $table, iterable $rows, array $columns = [], array &$params = []): string
     {
         if (!is_array($rows)) {
             $rows = $this->prepareTraversable($rows);
@@ -226,10 +240,11 @@ abstract class AbstractDMLQueryBuilder implements DMLQueryBuilderInterface
             $row = reset($rows);
         }
 
-        $row = match (true) {
-            is_array($row) => $row,
-            $row instanceof Traversable => iterator_to_array($row),
-            is_object($row) => get_object_vars($row),
+        $row = match (gettype($row)) {
+            'array' => $row,
+            'object' => $row instanceof Traversable
+                ? iterator_to_array($row)
+                : get_object_vars($row),
             default => [],
         };
 

--- a/src/QueryBuilder/AbstractDMLQueryBuilder.php
+++ b/src/QueryBuilder/AbstractDMLQueryBuilder.php
@@ -69,7 +69,7 @@ abstract class AbstractDMLQueryBuilder implements DMLQueryBuilderInterface
      * @psalm-param BatchValues $rows
      * @psalm-param ParamsType $params
      *
-     * @deprecated Use (@see insertBatch()) instead. It will be removed in version 3.0.0.
+     * @deprecated Use {@see insertBatch()} instead. It will be removed in version 3.0.0.
      */
     public function batchInsert(string $table, array $columns, iterable $rows, array &$params = []): string
     {

--- a/src/QueryBuilder/AbstractQueryBuilder.php
+++ b/src/QueryBuilder/AbstractQueryBuilder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Db\QueryBuilder;
 
 use Yiisoft\Db\Command\CommandInterface;
+use Yiisoft\Db\Connection\ConnectionInterface;
 use Yiisoft\Db\Expression\ExpressionInterface;
 use Yiisoft\Db\Query\QueryInterface;
 use Yiisoft\Db\QueryBuilder\Condition\Interface\ConditionInterface;
@@ -24,6 +25,9 @@ use function preg_replace;
  *
  * AbstractQueryBuilder is also used by {@see CommandInterface} to build SQL statements such as {@see insert()},
  * {@see update()}, {@see delete()} and {@see createTable()}.
+ *
+ * @psalm-import-type ParamsType from ConnectionInterface
+ * @psalm-import-type BatchValues from DMLQueryBuilderInterface
  */
 abstract class AbstractQueryBuilder implements QueryBuilderInterface
 {
@@ -108,9 +112,22 @@ abstract class AbstractQueryBuilder implements QueryBuilderInterface
         return $this->ddlBuilder->alterColumn($table, $column, $type);
     }
 
+    /**
+     * @param string[] $columns
+     *
+     * @psalm-param BatchValues $rows
+     * @psalm-param ParamsType $params
+     *
+     * @deprecated Use (@see insertBatch()) instead. It will be removed in version 3.0.0.
+     */
     public function batchInsert(string $table, array $columns, iterable $rows, array &$params = []): string
     {
-        return $this->dmlBuilder->batchInsert($table, $columns, $rows, $params);
+        return $this->dmlBuilder->insertBatch($table, $rows, $columns, $params);
+    }
+
+    public function insertBatch(string $table, iterable $rows, array $columns = [], array &$params = []): string
+    {
+        return $this->dmlBuilder->insertBatch($table, $rows, $columns, $params);
     }
 
     public function bindParam(mixed $value, array &$params = []): string

--- a/src/QueryBuilder/AbstractQueryBuilder.php
+++ b/src/QueryBuilder/AbstractQueryBuilder.php
@@ -118,7 +118,7 @@ abstract class AbstractQueryBuilder implements QueryBuilderInterface
      * @psalm-param BatchValues $rows
      * @psalm-param ParamsType $params
      *
-     * @deprecated Use (@see insertBatch()) instead. It will be removed in version 3.0.0.
+     * @deprecated Use {@see insertBatch()} instead. It will be removed in version 3.0.0.
      */
     public function batchInsert(string $table, array $columns, iterable $rows, array &$params = []): string
     {

--- a/src/QueryBuilder/DMLQueryBuilderInterface.php
+++ b/src/QueryBuilder/DMLQueryBuilderInterface.php
@@ -18,6 +18,7 @@ use Yiisoft\Db\Query\QueryInterface;
  * @link https://en.wikipedia.org/wiki/Data_manipulation_language
  *
  * @psalm-import-type ParamsType from ConnectionInterface
+ * @psalm-type BatchValues = iterable<iterable<array-key, mixed>>
  */
 interface DMLQueryBuilderInterface
 {
@@ -27,16 +28,26 @@ interface DMLQueryBuilderInterface
      * For example,
      *
      * ```php
-     * $sql = $queryBuilder->batchInsert('user', ['name', 'age'], [
+     * $sql = $queryBuilder->insertBatch('user', [
      *     ['Tom', 30],
      *     ['Jane', 20],
      *     ['Linda', 25],
+     * ], ['name', 'age']);
+     * ```
+     *
+     * or as associative arrays where the keys are column names
+     *
+     * ```php
+     * $queryBuilder->insertBatch('user', [
+     *     ['name' => 'Tom', 'age' => 30],
+     *     ['name' => 'Jane', 'age' => 20],
+     *     ['name' => 'Linda', 'age' => 25],
      * ]);
      * ```
      *
      * @param string $table The table to insert new rows into.
-     * @param string[] $columns The column names of the table.
      * @param iterable $rows The rows to batch-insert into the table.
+     * @param string[] $columns The column names of the table.
      * @param array $params The binding parameters. This parameter exists.
      *
      * @throws Exception
@@ -44,15 +55,14 @@ interface DMLQueryBuilderInterface
      *
      * @return string The batch INSERT SQL statement.
      *
-     * @psalm-param string[] $columns
-     * @psalm-param iterable<iterable<array-key, mixed>> $rows
+     * @psalm-param BatchValues $rows
      * @psalm-param ParamsType $params
      *
      * Note:
      * - That the values in each row must match the corresponding column names.
      * - The method will escape the column names, and quote the values to insert.
      */
-    public function batchInsert(string $table, array $columns, iterable $rows, array &$params = []): string;
+    public function insertBatch(string $table, iterable $rows, array $columns = [], array &$params = []): string;
 
     /**
      * Creates a `DELETE` SQL statement.

--- a/tests/AbstractQueryBuilderTest.php
+++ b/tests/AbstractQueryBuilderTest.php
@@ -214,8 +214,8 @@ abstract class AbstractQueryBuilderTest extends TestCase
      */
     public function testBatchInsert(
         string $table,
-        array $columns,
         iterable $rows,
+        array $columns,
         string $expected,
         array $expectedParams = [],
     ): void {
@@ -223,7 +223,7 @@ abstract class AbstractQueryBuilderTest extends TestCase
         $qb = $db->getQueryBuilder();
 
         $params = [];
-        $sql = $qb->batchInsert($table, $columns, $rows, $params);
+        $sql = $qb->insertBatch($table, $rows, $columns, $params);
 
         $this->assertSame($expected, $sql);
         $this->assertSame($expectedParams, $params);

--- a/tests/Common/CommonCommandTest.php
+++ b/tests/Common/CommonCommandTest.php
@@ -305,8 +305,8 @@ abstract class CommonCommandTest extends AbstractCommandTest
      */
     public function testBatchInsert(
         string $table,
-        array $columns,
         iterable $values,
+        array $columns,
         string $expected,
         array $expectedParams = [],
         int $insertedRow = 1
@@ -314,7 +314,7 @@ abstract class CommonCommandTest extends AbstractCommandTest
         $db = $this->getConnection(true);
 
         $command = $db->createCommand();
-        $command->batchInsert($table, $columns, $values);
+        $command->insertBatch($table, $values, $columns);
 
         $this->assertSame($expected, $command->getSql());
         $this->assertSame($expectedParams, $command->getParams());
@@ -370,7 +370,7 @@ abstract class CommonCommandTest extends AbstractCommandTest
             }
 
             /* batch insert on "type" table */
-            $command->batchInsert('{{type}}', $cols, $data)->execute();
+            $command->insertBatch('{{type}}', $data, $cols)->execute();
             $data = $command->setSql(
                 <<<SQL
                 SELECT [[int_col]], [[char_col]], [[float_col]], [[bool_col]] FROM {{type}} WHERE [[int_col]] IN (1,2,3) ORDER BY [[int_col]]
@@ -413,10 +413,10 @@ abstract class CommonCommandTest extends AbstractCommandTest
         $db = $this->getConnection(true);
 
         $command = $db->createCommand();
-        $command->batchInsert(
+        $command->insertBatch(
             '{{customer}}',
-            ['email', 'name', 'address'],
             [['t1@example.com', 'test_name', 'test_address']],
+            ['email', 'name', 'address'],
         );
 
         $this->assertSame(1, $command->execute());
@@ -450,7 +450,7 @@ abstract class CommonCommandTest extends AbstractCommandTest
             $values[$i] = ['t' . $i . '@any.com', 't' . $i, 't' . $i . ' address'];
         }
 
-        $command->batchInsert('{{customer}}', ['email', 'name', 'address'], $values);
+        $command->insertBatch('{{customer}}', $values, ['email', 'name', 'address']);
 
         $this->assertSame($attemptsInsertRows, $command->execute());
 
@@ -476,7 +476,7 @@ abstract class CommonCommandTest extends AbstractCommandTest
             }
         )();
         $command = $db->createCommand();
-        $command->batchInsert('{{customer}}', ['email', 'name', 'address'], $rows);
+        $command->insertBatch('{{customer}}', $rows, ['email', 'name', 'address']);
 
         $this->assertSame(1, $command->execute());
 

--- a/tests/Db/Command/CommandTest.php
+++ b/tests/Db/Command/CommandTest.php
@@ -187,7 +187,7 @@ final class CommandTest extends AbstractCommandTest
             'Yiisoft\Db\Tests\Support\Stub\Schema::loadTableSchema is not supported by this DBMS.'
         );
 
-        $command->batchInsert('table', ['column1', 'column2'], [['value1', 'value2'], ['value3', 'value4']]);
+        $command->insertBatch('table', [['value1', 'value2'], ['value3', 'value4']], ['column1', 'column2']);
     }
 
     /**

--- a/tests/Db/QueryBuilder/QueryBuilderTest.php
+++ b/tests/Db/QueryBuilder/QueryBuilderTest.php
@@ -50,8 +50,8 @@ final class QueryBuilderTest extends AbstractQueryBuilderTest
      */
     public function testBatchInsert(
         string $table,
-        array $columns,
         iterable $rows,
+        array $columns,
         string $expected,
         array $expectedParams = [],
     ): void {
@@ -62,7 +62,7 @@ final class QueryBuilderTest extends AbstractQueryBuilderTest
         $params = [];
 
         try {
-            $this->assertSame($expected, $qb->batchInsert($table, $columns, $rows, $params));
+            $this->assertSame($expected, $qb->insertBatch($table, $rows, $columns, $params));
             $this->assertSame($expectedParams, $params);
         } catch (InvalidArgumentException|Exception) {
         }

--- a/tests/Provider/CommandProvider.php
+++ b/tests/Provider/CommandProvider.php
@@ -263,11 +263,11 @@ class CommandProvider
         return [
             'multirow' => [
                 'type',
-                ['int_col', 'float_col', 'char_col', 'bool_col'],
                 'values' => [
                     ['0', '0.0', 'test string', true],
                     [false, 0, 'test string2', false],
                 ],
+                ['int_col', 'float_col', 'char_col', 'bool_col'],
                 'expected' => DbHelper::replaceQuotes(
                     <<<SQL
                     INSERT INTO [[type]] ([[int_col]], [[float_col]], [[char_col]], [[bool_col]]) VALUES (:qp0, :qp1, :qp2, :qp3), (:qp4, :qp5, :qp6, :qp7)
@@ -288,8 +288,8 @@ class CommandProvider
             ],
             'issue11242' => [
                 'type',
-                ['int_col', 'float_col', 'char_col', 'bool_col'],
                 'values' => [[1.0, 1.1, 'Kyiv {{city}}, Ukraine', true]],
+                ['int_col', 'float_col', 'char_col', 'bool_col'],
                 /**
                  * {@see https://github.com/yiisoft/yii2/issues/11242}
                  *
@@ -310,8 +310,8 @@ class CommandProvider
             ],
             'table name with column name with brackets' => [
                 '{{%type}}',
-                ['{{%type}}.[[int_col]]', '[[float_col]]', 'char_col', 'bool_col'],
                 'values' => [['0', '0.0', 'Kyiv {{city}}, Ukraine', false]],
+                ['{{%type}}.[[int_col]]', '[[float_col]]', 'char_col', 'bool_col'],
                 'expected' => DbHelper::replaceQuotes(
                     <<<SQL
                     INSERT INTO [[type]] ([[int_col]], [[float_col]], [[char_col]], [[bool_col]]) VALUES (:qp0, :qp1, :qp2, :qp3)
@@ -325,14 +325,14 @@ class CommandProvider
                     ':qp3' => false,
                 ],
             ],
-            'batchInsert binds params from expression' => [
+            'binds params from expression' => [
                 '{{%type}}',
-                ['int_col', 'float_col', 'char_col', 'bool_col'],
                 /**
                  * This example is completely useless. This feature of batchInsert is intended to be used with complex
                  * expression objects, such as JsonExpression.
                  */
                 'values' => [[new Expression(':exp1', [':exp1' => 42]), 1, 'test', false]],
+                ['int_col', 'float_col', 'char_col', 'bool_col'],
                 'expected' => DbHelper::replaceQuotes(
                     <<<SQL
                     INSERT INTO [[type]] ([[int_col]], [[float_col]], [[char_col]], [[bool_col]]) VALUES (:exp1, :qp1, :qp2, :qp3)
@@ -348,8 +348,8 @@ class CommandProvider
             ],
             'with associative values with different keys' => [
                 'type',
-                ['int_col', 'float_col', 'char_col', 'bool_col'],
                 'values' => [['int' => '1.0', 'float' => '2', 'char' => 10, 'bool' => 1]],
+                ['int_col', 'float_col', 'char_col', 'bool_col'],
                 'expected' => DbHelper::replaceQuotes(
                     <<<SQL
                     INSERT INTO [[type]] ([[int_col]], [[float_col]], [[char_col]], [[bool_col]]) VALUES (:qp0, :qp1, :qp2, :qp3)
@@ -365,8 +365,8 @@ class CommandProvider
             ],
             'with associative values with different keys and columns with keys' => [
                 'type',
-                ['a' => 'int_col', 'b' => 'float_col', 'c' => 'char_col', 'd' => 'bool_col'],
                 'values' => [['int' => '1.0', 'float' => '2', 'char' => 10, 'bool' => 1]],
+                ['a' => 'int_col', 'b' => 'float_col', 'c' => 'char_col', 'd' => 'bool_col'],
                 'expected' => DbHelper::replaceQuotes(
                     <<<SQL
                     INSERT INTO [[type]] ([[int_col]], [[float_col]], [[char_col]], [[bool_col]]) VALUES (:qp0, :qp1, :qp2, :qp3)
@@ -382,8 +382,8 @@ class CommandProvider
             ],
             'with associative values with keys of column names' => [
                 'type',
-                ['int_col', 'float_col', 'char_col', 'bool_col'],
                 'values' => [['bool_col' => 1, 'char_col' => 10, 'int_col' => '1.0', 'float_col' => '2']],
+                ['int_col', 'float_col', 'char_col', 'bool_col'],
                 'expected' => DbHelper::replaceQuotes(
                     <<<SQL
                     INSERT INTO [[type]] ([[int_col]], [[float_col]], [[char_col]], [[bool_col]]) VALUES (:qp2, :qp3, :qp1, :qp0)
@@ -399,8 +399,8 @@ class CommandProvider
             ],
             'with associative values with keys of column keys' => [
                 'type',
-                ['int' => 'int_col', 'float' => 'float_col', 'char' => 'char_col', 'bool' => 'bool_col'],
                 'values' => [['bool' => 1, 'char' => 10, 'int' => '1.0', 'float' => '2']],
+                ['int' => 'int_col', 'float' => 'float_col', 'char' => 'char_col', 'bool' => 'bool_col'],
                 'expected' => DbHelper::replaceQuotes(
                     <<<SQL
                     INSERT INTO [[type]] ([[int_col]], [[float_col]], [[char_col]], [[bool_col]]) VALUES (:qp2, :qp3, :qp1, :qp0)
@@ -416,8 +416,8 @@ class CommandProvider
             ],
             'with shuffled indexes of values' => [
                 'type',
-                ['int_col', 'float_col', 'char_col', 'bool_col'],
                 'values' => [[3 => 1, 2 => 10, 0 => '1.0', 1 => '2']],
+                ['int_col', 'float_col', 'char_col', 'bool_col'],
                 'expected' => DbHelper::replaceQuotes(
                     <<<SQL
                     INSERT INTO [[type]] ([[int_col]], [[float_col]], [[char_col]], [[bool_col]]) VALUES (:qp2, :qp3, :qp1, :qp0)
@@ -433,8 +433,8 @@ class CommandProvider
             ],
             'empty columns and associative values' => [
                 'type',
-                [],
                 'values' => [['int_col' => '1.0', 'float_col' => '2', 'char_col' => 10, 'bool_col' => 1]],
+                [],
                 'expected' => DbHelper::replaceQuotes(
                     <<<SQL
                     INSERT INTO [[type]] ([[int_col]], [[float_col]], [[char_col]], [[bool_col]]) VALUES (:qp0, :qp1, :qp2, :qp3)
@@ -450,8 +450,8 @@ class CommandProvider
             ],
             'empty columns and objects' => [
                 'type',
-                [],
                 'values' => [(object)['int_col' => '1.0', 'float_col' => '2', 'char_col' => 10, 'bool_col' => 1]],
+                [],
                 'expected' => DbHelper::replaceQuotes(
                     <<<SQL
                     INSERT INTO [[type]] ([[int_col]], [[float_col]], [[char_col]], [[bool_col]]) VALUES (:qp0, :qp1, :qp2, :qp3)
@@ -467,8 +467,8 @@ class CommandProvider
             ],
             'empty columns and a Traversable value' => [
                 'type',
-                [],
                 'values' => [new ArrayIterator(['int_col' => '1.0', 'float_col' => '2', 'char_col' => 10, 'bool_col' => 1])],
+                [],
                 'expected' => DbHelper::replaceQuotes(
                     <<<SQL
                     INSERT INTO [[type]] ([[int_col]], [[float_col]], [[char_col]], [[bool_col]]) VALUES (:qp0, :qp1, :qp2, :qp3)
@@ -484,13 +484,13 @@ class CommandProvider
             ],
             'empty columns and Traversable values' => [
                 'type',
-                [],
                 'values' => new class () implements IteratorAggregate {
                     public function getIterator(): Traversable
                     {
                         yield ['int_col' => '1.0', 'float_col' => '2', 'char_col' => 10, 'bool_col' => 1];
                     }
                 },
+                [],
                 'expected' => DbHelper::replaceQuotes(
                     <<<SQL
                     INSERT INTO [[type]] ([[int_col]], [[float_col]], [[char_col]], [[bool_col]]) VALUES (:qp0, :qp1, :qp2, :qp3)

--- a/tests/Provider/QueryBuilderProvider.php
+++ b/tests/Provider/QueryBuilderProvider.php
@@ -140,8 +140,8 @@ class QueryBuilderProvider
         return [
             'simple' => [
                 'customer',
-                ['email', 'name', 'address'],
                 [['test@example.com', 'silverfire', 'Kyiv {{city}}, Ukraine']],
+                ['email', 'name', 'address'],
                 'expected' => DbHelper::replaceQuotes(
                     <<<SQL
                     INSERT INTO [[customer]] ([[email]], [[name]], [[address]]) VALUES (:qp0, :qp1, :qp2)
@@ -152,8 +152,8 @@ class QueryBuilderProvider
             ],
             'escape-danger-chars' => [
                 'customer',
-                ['address'],
                 [["SQL-danger chars are escaped: '); --"]],
+                ['address'],
                 'expected' => DbHelper::replaceQuotes(
                     <<<SQL
                     INSERT INTO [[customer]] ([[address]]) VALUES (:qp0)
@@ -164,14 +164,14 @@ class QueryBuilderProvider
             ],
             'customer2' => [
                 'customer',
-                ['address'],
                 [],
+                ['address'],
                 '',
             ],
             'customer3' => [
                 'customer',
-                [],
                 [['no columns passed']],
+                [],
                 'expected' => DbHelper::replaceQuotes(
                     <<<SQL
                     INSERT INTO [[customer]] VALUES (:qp0)
@@ -182,8 +182,8 @@ class QueryBuilderProvider
             ],
             'bool-false, bool2-null' => [
                 'type',
-                ['bool_col', 'bool_col2'],
                 [[false, null]],
+                ['bool_col', 'bool_col2'],
                 'expected' => DbHelper::replaceQuotes(
                     <<<SQL
                     INSERT INTO [[type]] ([[bool_col]], [[bool_col2]]) VALUES (:qp0, :qp1)
@@ -194,8 +194,8 @@ class QueryBuilderProvider
             ],
             'wrong' => [
                 '{{%type}}',
-                ['{{%type}}.[[float_col]]', '[[time]]'],
                 [[null, new Expression('now()')], [null, new Expression('now()')]],
+                ['{{%type}}.[[float_col]]', '[[time]]'],
                 'expected' => DbHelper::replaceQuotes(
                     <<<SQL
                     INSERT INTO {{%type}} ([[float_col]], [[time]]) VALUES (:qp0, now()), (:qp1, now())
@@ -206,8 +206,8 @@ class QueryBuilderProvider
             ],
             'bool-false, time-now()' => [
                 '{{%type}}',
-                ['{{%type}}.[[bool_col]]', '[[time]]'],
                 [[false, new Expression('now()')]],
+                ['{{%type}}.[[bool_col]]', '[[time]]'],
                 'expected' => DbHelper::replaceQuotes(
                     <<<SQL
                     INSERT INTO {{%type}} ([[bool_col]], [[time]]) VALUES (:qp0, now())
@@ -218,8 +218,8 @@ class QueryBuilderProvider
             ],
             'column table names are not checked' => [
                 '{{%type}}',
-                ['{{%type}}.[[bool_col]]', '{{%another_table}}.[[bool_col2]]'],
                 [[true, false]],
+                ['{{%type}}.[[bool_col]]', '{{%another_table}}.[[bool_col2]]'],
                 'expected' => DbHelper::replaceQuotes(
                     <<<SQL
                     INSERT INTO {{%type}} ([[bool_col]], [[bool_col2]]) VALUES (:qp0, :qp1)
@@ -230,18 +230,18 @@ class QueryBuilderProvider
             ],
             'empty-sql' => [
                 '{{%type}}',
-                [],
                 (static function () {
                     if (false) {
                         yield [];
                     }
                 })(),
+                [],
                 '',
             ],
             'empty columns and non-exists table' => [
                 'non_exists_table',
-                [],
                 [['1.0', '2', 10, 1]],
+                [],
                 'expected' => DbHelper::replaceQuotes(
                     <<<SQL
                     INSERT INTO [[non_exists_table]] VALUES (:qp0, :qp1, :qp2, :qp3)


### PR DESCRIPTION
* Rename `batchInsert()` to `insertBatch()` in `DMLQueryBuilderInterface` and `CommandInterface`
* Change parameters order to from `$table, $columns, $rows` to `$table, $rows, $columns`
* Add default value `[]` for `$columns` parameter

From `batchInsert(string $table, array $columns, iterable $rows)`
to `insertBatch(string $table, iterable $rows, array $columns = [])`

### Related PRs
* yiisoft/db-sqlite#301
* yiisoft/db-mysql#334
* yiisoft/db-pgsql#344
* yiisoft/db-oracle#268
* yiisoft/db-mssql#302

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | #772