### PR TITLE
Fix psalm

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,23 +1,15 @@
 on:
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - 'README.md'
-      - 'CHANGELOG.md'
-      - '.gitignore'
-      - '.gitattributes'
-      - 'infection.json.dist'
-      - 'phpunit.xml.dist'
+    paths:
+      - 'src/**'
+      - 'config/**'
+      - 'psalm*.xml'
 
   push:
-    paths-ignore:
-      - 'docs/**'
-      - 'README.md'
-      - 'CHANGELOG.md'
-      - '.gitignore'
-      - '.gitattributes'
-      - 'infection.json.dist'
-      - 'phpunit.xml.dist'
+    paths:
+      - 'src/**'
+      - 'config/**'
+      - 'psalm*.xml'
 
 name: static analysis
 
@@ -28,4 +20,12 @@ jobs:
       os: >-
         ['ubuntu-latest']
       php: >-
-        ['8.1', '8.2', '8.3']
+        ['8.1', '8.2']
+  psalm83:
+    uses: yiisoft/actions/.github/workflows/psalm.yml@master
+    with:
+      psalm-config: psalm83.xml
+      os: >-
+        ['ubuntu-latest']
+      php: >-
+        ['8.3']

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "rector/rector": "^1.0",
         "roave/infection-static-analysis-plugin": "^1.16",
         "spatie/phpunit-watcher": "^1.23",
-        "vimeo/psalm": "^4.30|^5.20",
+        "vimeo/psalm": "^5.24",
         "yiisoft/aliases": "^3.0",
         "yiisoft/cache-file": "^3.1",
         "yiisoft/di": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "rector/rector": "^1.0",
         "roave/infection-static-analysis-plugin": "^1.16",
         "spatie/phpunit-watcher": "^1.23",
-        "vimeo/psalm": "^5.24",
+        "vimeo/psalm": "^4.30|^5.24",
         "yiisoft/aliases": "^3.0",
         "yiisoft/cache-file": "^3.1",
         "yiisoft/di": "^1.0",

--- a/psalm83.xml
+++ b/psalm83.xml
@@ -17,5 +17,6 @@
   <issueHandlers>
     <MixedAssignment errorLevel="suppress" />
     <RiskyTruthyFalsyComparison errorLevel="suppress" />
+    <MissingClassConstType errorLevel="suppress" />
   </issueHandlers>
 </psalm>

--- a/src/Driver/Pdo/AbstractPdoCommand.php
+++ b/src/Driver/Pdo/AbstractPdoCommand.php
@@ -144,7 +144,6 @@ abstract class AbstractPdoCommand extends AbstractCommand implements PdoCommandI
             $this->bindPendingParams();
         } catch (PDOException $e) {
             $message = $e->getMessage() . "\nFailed to prepare SQL: $sql";
-            /** @psalm-var array|null $errorInfo */
             $errorInfo = $e->errorInfo ?? null;
 
             throw new Exception($message, $errorInfo, $e);

--- a/src/Driver/Pdo/AbstractPdoSchema.php
+++ b/src/Driver/Pdo/AbstractPdoSchema.php
@@ -21,8 +21,6 @@ abstract class AbstractPdoSchema extends AbstractSchema
      */
     protected function generateCacheKey(): array
     {
-        $cacheKey = [];
-
         if ($this->db instanceof PdoConnectionInterface) {
             $cacheKey = [$this->db->getDriver()->getDsn(), $this->db->getDriver()->getUsername()];
         } else {

--- a/src/Exception/ConvertException.php
+++ b/src/Exception/ConvertException.php
@@ -31,7 +31,6 @@ final class ConvertException
     {
         $message = $this->e->getMessage() . PHP_EOL . 'The SQL being executed was: ' . $this->rawSql;
 
-        /** @var array|null $errorInfo */
         $errorInfo = $this->e instanceof PDOException ? $this->e->errorInfo : null;
 
         return match (

--- a/src/Expression/AbstractExpressionBuilder.php
+++ b/src/Expression/AbstractExpressionBuilder.php
@@ -99,7 +99,6 @@ abstract class AbstractExpressionBuilder implements ExpressionBuilderInterface
 
         $replacements = [];
 
-        /** @var non-empty-string $name */
         foreach ($nonUniqueParams as $name => $value) {
             $paramName = $name[0] === ':' ? substr($name, 1) : $name;
             $uniqueName = $this->getUniqueName($paramName, $params);

--- a/src/QueryBuilder/Condition/Builder/HashConditionBuilder.php
+++ b/src/QueryBuilder/Condition/Builder/HashConditionBuilder.php
@@ -44,7 +44,6 @@ class HashConditionBuilder implements ExpressionBuilderInterface
 
         /**
          * @psalm-var array<string, array|mixed> $hash
-         * @psalm-var array|mixed $value
          */
         foreach ($hash as $column => $value) {
             if (is_iterable($value) || $value instanceof QueryInterface) {

--- a/src/QueryBuilder/DQLQueryBuilderInterface.php
+++ b/src/QueryBuilder/DQLQueryBuilderInterface.php
@@ -301,8 +301,6 @@ interface DQLQueryBuilderInterface
      * @throws InvalidArgumentException
      *
      * @return object Instance of {@see ExpressionBuilderInterface} for the given expression.
-     *
-     * @psalm-suppress InvalidStringClass
      */
     public function getExpressionBuilder(ExpressionInterface $expression): object;
 


### PR DESCRIPTION
1. Replace `paths-ignore` to clear `paths`
2. Fix issue with `MissingClassConstType` for PHP version less then `8.3`
3. Added two new parameters to config:
    * findUnusedVariablesAndParams="true"
    * findUnusedPsalmSuppress="true"
4. Clear code