### PR TITLE
Remove `$table` parameter from `normalizeColumnNames()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   and change parameters from `$table, $columns, $rows` to `$table, $rows, $columns = []` (@Tigrov)
 - Enh #834: Refactor `AbstractCommand::insertBatch()`, add `Quoter::getRawTableName()` to `QuoterInterface` (@Tigrov)
 - Chg #836: Remove `AbstractDMLQueryBuilder::getTypecastValue()` method (@Tigrov)
+- Chg #767: Remove `$table` parameter from `normalizeColumnNames()` and `getNormalizeColumnNames()` methods 
+  of `AbstractDMLQueryBuilder` class (@Tigrov)
 
 ## 1.3.0 March 21, 2024
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -62,3 +62,8 @@ $db->createCommand()->insertBatch('user', $values)->execute();
 ### Remove deprecated methods
 
 - `AbstractDMLQueryBuilder::getTypecastValue()`
+
+### Remove deprecated parameters
+
+- `$table` parameter from `AbstractDMLQueryBuilder::normalizeColumnNames()` method
+- `$table` parameter from `AbstractDMLQueryBuilder::getNormalizeColumnNames()` method

--- a/src/QueryBuilder/AbstractDMLQueryBuilder.php
+++ b/src/QueryBuilder/AbstractDMLQueryBuilder.php
@@ -227,7 +227,7 @@ abstract class AbstractDMLQueryBuilder implements DMLQueryBuilderInterface
      */
     protected function extractColumnNames(array|Iterator $rows, array $columns): array
     {
-        $columns = $this->getNormalizeColumnNames('', $columns);
+        $columns = $this->getNormalizeColumnNames($columns);
 
         if (!empty($columns)) {
             return $columns;
@@ -332,7 +332,7 @@ abstract class AbstractDMLQueryBuilder implements DMLQueryBuilderInterface
 
         $names = [];
         $placeholders = [];
-        $columns = $this->normalizeColumnNames('', $columns);
+        $columns = $this->normalizeColumnNames($columns);
         $columnSchemas = $this->schema->getTableSchema($table)?->getColumns() ?? [];
 
         foreach ($columns as $name => $value) {
@@ -366,7 +366,7 @@ abstract class AbstractDMLQueryBuilder implements DMLQueryBuilderInterface
     protected function prepareUpdateSets(string $table, array $columns, array $params = []): array
     {
         $sets = [];
-        $columns = $this->normalizeColumnNames('', $columns);
+        $columns = $this->normalizeColumnNames($columns);
         $columnSchemas = $this->schema->getTableSchema($table)?->getColumns() ?? [];
 
         foreach ($columns as $name => $value) {
@@ -410,7 +410,7 @@ abstract class AbstractDMLQueryBuilder implements DMLQueryBuilderInterface
         if ($insertColumns instanceof QueryInterface) {
             [$insertNames] = $this->prepareInsertSelectSubQuery($insertColumns);
         } else {
-            $insertNames = $this->getNormalizeColumnNames('', array_keys($insertColumns));
+            $insertNames = $this->getNormalizeColumnNames(array_keys($insertColumns));
 
             $insertNames = array_map(
                 [$this->quoter, 'quoteColumnName'],
@@ -513,18 +513,17 @@ abstract class AbstractDMLQueryBuilder implements DMLQueryBuilderInterface
     /**
      * Normalizes the column names.
      *
-     * @param string $table Not used. Could be empty string. Will be removed in version 2.0.0.
      * @param array $columns The column data (name => value).
      *
      * @return array The normalized column names (name => value).
      *
      * @psalm-return array<string, mixed>
      */
-    protected function normalizeColumnNames(string $table, array $columns): array
+    protected function normalizeColumnNames(array $columns): array
     {
         /** @var string[] $columnNames */
         $columnNames = array_keys($columns);
-        $normalizedNames = $this->getNormalizeColumnNames('', $columnNames);
+        $normalizedNames = $this->getNormalizeColumnNames($columnNames);
 
         return array_combine($normalizedNames, $columns);
     }
@@ -532,12 +531,11 @@ abstract class AbstractDMLQueryBuilder implements DMLQueryBuilderInterface
     /**
      * Get normalized column names
      *
-     * @param string $table Not used. Could be empty string. Will be removed in version 2.0.0.
      * @param string[] $columns The column names.
      *
      * @return string[] Normalized column names.
      */
-    protected function getNormalizeColumnNames(string $table, array $columns): array
+    protected function getNormalizeColumnNames(array $columns): array
     {
         foreach ($columns as &$name) {
             $name = $this->quoter->ensureColumnName($name);


### PR DESCRIPTION
Remove `$table` parameter from `normalizeColumnNames()` and `getNormalizeColumnNames()` methods of `AbstractDMLQueryBuilder` class

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | #767
