### PR TITLE
Remove `TableSchemaInterface::compositeForeignKey()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Chg #837: Remove `$table` parameter from `normalizeColumnNames()` and `getNormalizeColumnNames()` methods 
   of `AbstractDMLQueryBuilder` class (@Tigrov)
 - Chg #838: Remove `SchemaInterface::TYPE_JSONB` constant (@Tigrov)
+- Chg #839: Remove `TableSchemaInterface::compositeForeignKey()` method (@Tigrov)
 
 ## 1.3.0 March 21, 2024
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -62,6 +62,7 @@ $db->createCommand()->insertBatch('user', $values)->execute();
 ### Remove deprecated methods
 
 - `AbstractDMLQueryBuilder::getTypecastValue()`
+- `TableSchemaInterface::compositeForeignKey()`
 
 ### Remove deprecated parameters
 

--- a/src/Schema/AbstractTableSchema.php
+++ b/src/Schema/AbstractTableSchema.php
@@ -152,9 +152,4 @@ abstract class AbstractTableSchema implements TableSchemaInterface
     {
         $this->foreignKeys[$id] = $to;
     }
-
-    public function compositeForeignKey(int $id, string $from, string $to): void
-    {
-        throw new NotSupportedException(static::class . ' does not support composite FK.');
-    }
 }

--- a/src/Schema/AbstractTableSchema.php
+++ b/src/Schema/AbstractTableSchema.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Yiisoft\Db\Schema;
 
-use Yiisoft\Db\Exception\NotSupportedException;
-
 use function array_keys;
 
 /**

--- a/src/Schema/TableSchemaInterface.php
+++ b/src/Schema/TableSchemaInterface.php
@@ -201,17 +201,4 @@ interface TableSchemaInterface
      * @param array $to The foreign key.
      */
     public function foreignKey(string|int $id, array $to): void;
-
-    /**
-     * Set composite foreign key.
-     *
-     * @param int $id The index of foreign key.
-     * @param string $from The column name in current table.
-     * @param string $to The column name in foreign table.
-     *
-     * @throws NotSupportedException
-     *
-     * @deprecated will be removed in version 2.0.0
-     */
-    public function compositeForeignKey(int $id, string $from, string $to): void;
 }

--- a/src/Schema/TableSchemaInterface.php
+++ b/src/Schema/TableSchemaInterface.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Yiisoft\Db\Schema;
 
-use Yiisoft\Db\Exception\NotSupportedException;
-
 /**
  * Represents the metadata of a database table.
  *

--- a/tests/AbstractTableSchemaTest.php
+++ b/tests/AbstractTableSchemaTest.php
@@ -14,16 +14,6 @@ abstract class AbstractTableSchemaTest extends TestCase
 {
     use TestTrait;
 
-    public function testCompositeFk(): void
-    {
-        $tableSchema = new TableSchema();
-
-        $this->expectException(NotSupportedException::class);
-        $this->expectExceptionMessage('Yiisoft\Db\Tests\Support\Stub\TableSchema does not support composite FK.');
-
-        $tableSchema->compositeForeignKey(1, 'from', 'to');
-    }
-
     public function testGetCatalogName(): void
     {
         $tableSchema = new TableSchema();

--- a/tests/AbstractTableSchemaTest.php
+++ b/tests/AbstractTableSchemaTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Yiisoft\Db\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Yiisoft\Db\Exception\NotSupportedException;
 use Yiisoft\Db\Tests\Support\Stub\ColumnSchema;
 use Yiisoft\Db\Tests\Support\Stub\TableSchema;
 use Yiisoft\Db\Tests\Support\TestTrait;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | #767
