### PR TITLE
Remove parameter `$withColumn` from `Quoter::getTableNameParts()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
   of `AbstractDMLQueryBuilder` class (@Tigrov)
 - Chg #838: Remove `SchemaInterface::TYPE_JSONB` constant (@Tigrov)
 - Chg #839: Remove `TableSchemaInterface::compositeForeignKey()` method (@Tigrov)
+- Chg #840: Remove parameter `$withColumn` from `QuoterInterface::getTableNameParts()` method (@Tigrov)
+- Chg #840: Remove `Quoter::unquoteParts()` method (@Tigrov)
 
 ## 1.3.0 March 21, 2024
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -59,15 +59,17 @@ $db->createCommand()->insertBatch('user', $values)->execute();
 
 - `QuoterInterface::getRawTableName()` - returns the raw table name without quotes.
 
-### Remove deprecated methods
+### Remove methods
 
 - `AbstractDMLQueryBuilder::getTypecastValue()`
 - `TableSchemaInterface::compositeForeignKey()`
+- `Quoter::unquoteParts()`
 
 ### Remove deprecated parameters
 
-- `$table` parameter from `AbstractDMLQueryBuilder::normalizeColumnNames()` method
-- `$table` parameter from `AbstractDMLQueryBuilder::getNormalizeColumnNames()` method
+- `$table` from `AbstractDMLQueryBuilder::normalizeColumnNames()` method
+- `$table` from `AbstractDMLQueryBuilder::getNormalizeColumnNames()` method
+- `$withColumn` from `QuoterInterface::getTableNameParts()` method
 
 ### Remove deprecated constants
 

--- a/src/Schema/Quoter.php
+++ b/src/Schema/Quoter.php
@@ -8,6 +8,7 @@ use Yiisoft\Db\Exception\InvalidArgumentException;
 use Yiisoft\Db\Expression\ExpressionInterface;
 
 use function addcslashes;
+use function array_map;
 use function array_slice;
 use function count;
 use function explode;
@@ -94,11 +95,11 @@ class Quoter implements QuoterInterface
         return $name;
     }
 
-    public function getTableNameParts(string $name, bool $withColumn = false): array
+    public function getTableNameParts(string $name): array
     {
         $parts = array_slice(explode('.', $name), -2, 2);
 
-        return $this->unquoteParts($parts, $withColumn);
+        return array_map([$this, 'unquoteSimpleTableName'], $parts);
     }
 
     public function ensureNameQuoted(string $name): string
@@ -244,23 +245,5 @@ class Quoter implements QuoterInterface
         return !str_starts_with($name, $startingCharacter)
             ? $name
             : substr($name, 1, -1);
-    }
-
-    /**
-     * @psalm-param string[] $parts Parts of table name
-     *
-     * @psalm-return string[]
-     */
-    protected function unquoteParts(array $parts, bool $withColumn): array
-    {
-        $lastKey = count($parts) - 1;
-
-        foreach ($parts as $k => &$part) {
-            $part = ($withColumn && $lastKey === $k) ?
-                $this->unquoteSimpleColumnName($part) :
-                $this->unquoteSimpleTableName($part);
-        }
-
-        return $parts;
     }
 }

--- a/src/Schema/QuoterInterface.php
+++ b/src/Schema/QuoterInterface.php
@@ -42,11 +42,10 @@ interface QuoterInterface
      * Splits full table name into parts.
      *
      * @param string $name The full name of the table.
-     * @param bool $withColumn Deprecated. Will be removed in version 2.0.0.
      *
      * @return string[] The table name parts.
      */
-    public function getTableNameParts(string $name, bool $withColumn = false): array;
+    public function getTableNameParts(string $name): array;
 
     /**
      * Ensures name is wrapped with `{{ and }}`.


### PR DESCRIPTION
### Related PR

* yiisoft/db-mssql#306

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | #767
