### PR TITLE
Remove `$rawSql` parameter from `AbstractCommand::internalExecute()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 - Chg #839: Remove `TableSchemaInterface::compositeForeignKey()` method (@Tigrov)
 - Chg #840: Remove parameter `$withColumn` from `QuoterInterface::getTableNameParts()` method (@Tigrov)
 - Chg #840: Remove `Quoter::unquoteParts()` method (@Tigrov)
+- Chg #841: Remove `$rawSql` parameter from `AbstractCommand::internalExecute()` method 
+  and `AbstractPdoCommand::internalExecute()` method (@Tigrov)
 
 ## 1.3.0 March 21, 2024
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -70,6 +70,8 @@ $db->createCommand()->insertBatch('user', $values)->execute();
 - `$table` from `AbstractDMLQueryBuilder::normalizeColumnNames()` method
 - `$table` from `AbstractDMLQueryBuilder::getNormalizeColumnNames()` method
 - `$withColumn` from `QuoterInterface::getTableNameParts()` method
+- `$rawSql` from `AbstractCommand::internalExecute()` method
+- `$rawSql` from `AbstractPdoCommand::internalExecute()` method
 
 ### Remove deprecated constants
 

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -556,12 +556,10 @@ abstract class AbstractCommand implements CommandInterface
     /**
      * Executes a prepared statement.
      *
-     * @param string|null $rawSql Deprecated. Use `null` value. Will be removed in version 2.0.0.
-     *
      * @throws Exception
      * @throws Throwable
      */
-    abstract protected function internalExecute(string|null $rawSql): void;
+    abstract protected function internalExecute(): void;
 
     /**
      * Check if the value has a given flag.
@@ -589,7 +587,7 @@ abstract class AbstractCommand implements CommandInterface
         $isReadMode = $this->isReadMode($queryMode);
         $this->prepare($isReadMode);
 
-        $this->internalExecute(null);
+        $this->internalExecute();
 
         /** @psalm-var mixed $result */
         $result = $this->internalGetQueryResult($queryMode);

--- a/src/Driver/Pdo/AbstractPdoCommand.php
+++ b/src/Driver/Pdo/AbstractPdoCommand.php
@@ -185,12 +185,10 @@ abstract class AbstractPdoCommand extends AbstractCommand implements PdoCommandI
      *
      * It's a wrapper around {@see PDOStatement::execute()} to support transactions and retry handlers.
      *
-     * @param string|null $rawSql Deprecated. Use `null` value. Will be removed in version 2.0.0.
-     *
      * @throws Exception
      * @throws Throwable
      */
-    protected function internalExecute(string|null $rawSql): void
+    protected function internalExecute(): void
     {
         $attempt = 0;
 
@@ -202,7 +200,7 @@ abstract class AbstractPdoCommand extends AbstractCommand implements PdoCommandI
                     && $this->db->getTransaction() === null
                 ) {
                     $this->db->transaction(
-                        fn () => $this->internalExecute($rawSql),
+                        fn () => $this->internalExecute(),
                         $this->isolationLevel
                     );
                 } else {

--- a/tests/Common/CommonCommandTest.php
+++ b/tests/Common/CommonCommandTest.php
@@ -1973,7 +1973,7 @@ abstract class CommonCommandTest extends AbstractCommandTest
             {
             }
 
-            protected function internalExecute(string|null $rawSql): void
+            protected function internalExecute(): void
             {
             }
         };

--- a/tests/Common/CommonPdoCommandTest.php
+++ b/tests/Common/CommonPdoCommandTest.php
@@ -218,7 +218,7 @@ abstract class CommonPdoCommandTest extends TestCase
             {
             }
 
-            protected function internalExecute(?string $rawSql): void
+            protected function internalExecute(): void
             {
             }
         };

--- a/tests/Support/Stub/Command.php
+++ b/tests/Support/Stub/Command.php
@@ -25,7 +25,7 @@ final class Command extends AbstractPdoCommand
         return $this->db->getQueryBuilder();
     }
 
-    protected function internalExecute(string|null $rawSql): void
+    protected function internalExecute(): void
     {
         throw new NotSupportedException(__METHOD__ . ' is not supported by this DBMS.');
     }


### PR DESCRIPTION
Remove `$rawSql` parameter from

* `AbstractCommand::internalExecute()` method
* `AbstractPdoCommand::internalExecute()` method

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | #767
