### PR TITLE
Allow `ExpressionInterface` for `$alias` parameter of `QueryPartsInterface::withQuery()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,10 @@
 - Chg #838: Remove `SchemaInterface::TYPE_JSONB` constant (@Tigrov)
 - Chg #839: Remove `TableSchemaInterface::compositeForeignKey()` method (@Tigrov)
 - Chg #840: Remove parameter `$withColumn` from `QuoterInterface::getTableNameParts()` method (@Tigrov)
-- Chg #840: Remove `Quoter::unquoteParts()` method (@Tigrov)
-- Chg #841: Remove `$rawSql` parameter from `AbstractCommand::internalExecute()` method 
+- Enh #840: Remove `Quoter::unquoteParts()` method (@Tigrov)
+- Chg #841: Remove `$rawSql` parameter from `AbstractCommand::internalExecute()` method
   and `AbstractPdoCommand::internalExecute()` method (@Tigrov)
+- Enh #842: Allow `ExpressionInterface` for `$alias` parameter of `QueryPartsInterface::withQuery()` method (@Tigrov)
 
 ## 1.3.0 March 21, 2024
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -76,3 +76,7 @@ $db->createCommand()->insertBatch('user', $values)->execute();
 ### Remove deprecated constants
 
 - `SchemaInterface::TYPE_JSONB`
+
+### Other changes
+
+- Allow `ExpressionInterface` for `$alias` parameter of `QueryPartsInterface::withQuery()` method

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -669,8 +669,11 @@ class Query implements QueryInterface
         return $this;
     }
 
-    public function withQuery(QueryInterface|string $query, ExpressionInterface|string $alias, bool $recursive = false): static
-    {
+    public function withQuery(
+        QueryInterface|string $query,
+        ExpressionInterface|string $alias,
+        bool $recursive = false
+    ): static {
         $this->withQueries[] = ['query' => $query, 'alias' => $alias, 'recursive' => $recursive];
         return $this;
     }

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -669,7 +669,7 @@ class Query implements QueryInterface
         return $this;
     }
 
-    public function withQuery(QueryInterface|string $query, string $alias, bool $recursive = false): static
+    public function withQuery(QueryInterface|string $query, ExpressionInterface|string $alias, bool $recursive = false): static
     {
         $this->withQueries[] = ['query' => $query, 'alias' => $alias, 'recursive' => $recursive];
         return $this;

--- a/src/Query/QueryPartsInterface.php
+++ b/src/Query/QueryPartsInterface.php
@@ -684,7 +684,11 @@ interface QueryPartsInterface
      * To specify the alias in plain SQL, you may pass an instance of {@see ExpressionInterface}.
      * @param bool $recursive Its `true` if using `WITH RECURSIVE` and `false` if using `WITH`.
      */
-    public function withQuery(QueryInterface|string $query, ExpressionInterface|string $alias, bool $recursive = false): static;
+    public function withQuery(
+        QueryInterface|string $query,
+        ExpressionInterface|string $alias,
+        bool $recursive = false
+    ): static;
 
     /**
      * Specifies the `WITH` query clause for the query.

--- a/src/Query/QueryPartsInterface.php
+++ b/src/Query/QueryPartsInterface.php
@@ -680,10 +680,11 @@ interface QueryPartsInterface
      * Prepends an SQL statement using `WITH` syntax.
      *
      * @param QueryInterface|string $query The SQL statement to append using `UNION`.
-     * @param string $alias The query alias in `WITH` construction.
+     * @param ExpressionInterface|string $alias The query alias in `WITH` construction.
+     * To specify the alias in plain SQL, you may pass an instance of {@see ExpressionInterface}.
      * @param bool $recursive Its `true` if using `WITH RECURSIVE` and `false` if using `WITH`.
      */
-    public function withQuery(QueryInterface|string $query, string $alias, bool $recursive = false): static;
+    public function withQuery(QueryInterface|string $query, ExpressionInterface|string $alias, bool $recursive = false): static;
 
     /**
      * Specifies the `WITH` query clause for the query.

--- a/tests/Provider/QueryBuilderProvider.php
+++ b/tests/Provider/QueryBuilderProvider.php
@@ -1527,6 +1527,7 @@ class QueryBuilderProvider
             'with one column' => ['a(b)', '[[a]]([[b]])'],
             'with columns' => ['a(b,c,d)', '[[a]]([[b]], [[c]], [[d]])'],
             'with extra space' => ['a(b,c,d) ', 'a(b,c,d) '],
+            'expression' => [new Expression('a(b,c,d)'), 'a(b,c,d)'],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | #767
