### PR TITLE
Remove `AbstractSchema::normalizeRowKeyCase()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
   and `AbstractPdoCommand::internalExecute()` method (@Tigrov)
 - Enh #842: Allow `ExpressionInterface` for `$alias` parameter of `QueryPartsInterface::withQuery()` method (@Tigrov)
 - Enh #843: Remove `AbstractPdoCommand::logQuery()` method (@Tigrov)
-- Chg #844: Remove `AbstractSchema::normalizeRowKeyCase()` method (@Tigrov)
+- Chg #845: Remove `AbstractSchema::normalizeRowKeyCase()` method (@Tigrov)
 
 ## 1.3.0 March 21, 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
   and `AbstractPdoCommand::internalExecute()` method (@Tigrov)
 - Enh #842: Allow `ExpressionInterface` for `$alias` parameter of `QueryPartsInterface::withQuery()` method (@Tigrov)
 - Enh #843: Remove `AbstractPdoCommand::logQuery()` method (@Tigrov)
+- Chg #844: Remove `AbstractSchema::normalizeRowKeyCase()` method (@Tigrov)
 
 ## 1.3.0 March 21, 2024
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -65,6 +65,7 @@ $db->createCommand()->insertBatch('user', $values)->execute();
 
 - `AbstractDMLQueryBuilder::getTypecastValue()`
 - `TableSchemaInterface::compositeForeignKey()`
+- `AbstractSchema::normalizeRowKeyCase()`
 - `Quoter::unquoteParts()`
 - `AbstractPdoCommand::logQuery()`
 

--- a/src/Schema/AbstractSchema.php
+++ b/src/Schema/AbstractSchema.php
@@ -530,26 +530,6 @@ abstract class AbstractSchema implements SchemaInterface
     }
 
     /**
-     * Change row's array key case to lower.
-     *
-     * @param array $row Thew row's array or an array of row arrays.
-     * @param bool $multiple Whether many rows or a single row passed.
-     *
-     * @return array The normalized row or rows.
-     *
-     * @deprecated Use `array_change_key_case($row)` or `array_map('array_change_key_case', $row)`.
-     * Will be removed in version 2.0.0.
-     */
-    protected function normalizeRowKeyCase(array $row, bool $multiple): array
-    {
-        if ($multiple) {
-            return array_map(static fn (array $row) => array_change_key_case($row), $row);
-        }
-
-        return array_change_key_case($row);
-    }
-
-    /**
      * Resolves the table name and schema name (if any).
      *
      * @param string $name The table name.

--- a/tests/Db/Schema/SchemaTest.php
+++ b/tests/Db/Schema/SchemaTest.php
@@ -336,25 +336,6 @@ final class SchemaTest extends AbstractSchemaTest
         $this->assertSame([], $schema->getViewNames());
     }
 
-    /**
-     * @throws ReflectionException
-     */
-    public function testNormaliceRowKeyCase(): void
-    {
-        $db = $this->getConnection();
-
-        $schema = $db->getSchema();
-
-        $this->assertSame(
-            ['fk_test' => 1],
-            Assert::InvokeMethod($schema, 'normalizeRowKeyCase', [['Fk_test' => 1], false]),
-        );
-        $this->assertSame(
-            ['FK_test' => ['uk_test' => 1]],
-            Assert::InvokeMethod($schema, 'normalizeRowKeyCase', [['FK_test' => ['UK_test' => 1]], true]),
-        );
-    }
-
     public function testRefreshTableSchema(): void
     {
         $db = $this->getConnection(true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | #767
