### PR TITLE
Remove `SchemaInterface::getRawTableName()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@
 - Enh #842: Allow `ExpressionInterface` for `$alias` parameter of `QueryPartsInterface::withQuery()` method (@Tigrov)
 - Enh #843: Remove `AbstractPdoCommand::logQuery()` method (@Tigrov)
 - Chg #845: Remove `AbstractSchema::normalizeRowKeyCase()` method (@Tigrov)
-- Chg #846: Remove `SchemaInterface::isReadQuery()` method (@Tigrov)
+- Chg #846: Remove `SchemaInterface::isReadQuery()` and `AbstractSchema::isReadQuery()` methods (@Tigrov)
+- Chg #847: Remove `SchemaInterface::getRawTableName()` and `AbstractSchema::getRawTableName()` methods (@Tigrov)
 
 ## 1.3.0 March 21, 2024
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -67,6 +67,8 @@ $db->createCommand()->insertBatch('user', $values)->execute();
 - `TableSchemaInterface::compositeForeignKey()`
 - `SchemaInterface::isReadQuery()`
 - `AbstractSchema::isReadQuery()`
+- `SchemaInterface::getRawTableName()`
+- `AbstractSchema::getRawTableName()`
 - `AbstractSchema::normalizeRowKeyCase()`
 - `Quoter::unquoteParts()`
 - `AbstractPdoCommand::logQuery()`

--- a/src/Schema/AbstractSchema.php
+++ b/src/Schema/AbstractSchema.php
@@ -15,9 +15,6 @@ use Yiisoft\Db\Exception\NotSupportedException;
 
 use function gettype;
 use function is_array;
-use function preg_replace;
-use function str_contains;
-use function str_replace;
 
 /**
  * Provides a set of methods for working with database schemas such as creating, modifying, and inspecting tables,

--- a/src/Schema/AbstractSchema.php
+++ b/src/Schema/AbstractSchema.php
@@ -141,18 +141,6 @@ abstract class AbstractSchema implements SchemaInterface
         };
     }
 
-    /** @deprecated Use {@see Quoter::getRawTableName()}. Will be removed in version 2.0.0. */
-    public function getRawTableName(string $name): string
-    {
-        if (str_contains($name, '{{')) {
-            $name = preg_replace('/{{(.*?)}}/', '\1', $name);
-
-            return str_replace('%', $this->db->getTablePrefix(), $name);
-        }
-
-        return $name;
-    }
-
     /**
      * @throws InvalidArgumentException
      * @throws NotSupportedException
@@ -331,8 +319,7 @@ abstract class AbstractSchema implements SchemaInterface
      */
     public function refreshTableSchema(string $name): void
     {
-        /** @psalm-suppress DeprecatedMethod */
-        $rawName = $this->getRawTableName($name);
+        $rawName = $this->db->getQuoter()->getRawTableName($name);
 
         unset($this->tableMetadata[$rawName]);
 
@@ -462,8 +449,7 @@ abstract class AbstractSchema implements SchemaInterface
      */
     protected function getTableMetadata(string $name, string $type, bool $refresh = false): mixed
     {
-        /** @psalm-suppress DeprecatedMethod */
-        $rawName = $this->getRawTableName($name);
+        $rawName = $this->db->getQuoter()->getRawTableName($name);
 
         if (!isset($this->tableMetadata[$rawName])) {
             $this->loadTableMetadataFromCache($rawName);
@@ -543,11 +529,8 @@ abstract class AbstractSchema implements SchemaInterface
      */
     protected function setTableMetadata(string $name, string $type, mixed $data): void
     {
-        /**
-         * @psalm-suppress MixedArrayAssignment
-         * @psalm-suppress DeprecatedMethod
-         */
-        $this->tableMetadata[$this->getRawTableName($name)][$type] = $data;
+        /** @psalm-suppress MixedArrayAssignment */
+        $this->tableMetadata[$this->db->getQuoter()->getRawTableName($name)][$type] = $data;
     }
 
     /**

--- a/src/Schema/SchemaInterface.php
+++ b/src/Schema/SchemaInterface.php
@@ -270,20 +270,6 @@ interface SchemaInterface extends ConstraintSchemaInterface
     public function getDataType(mixed $data): int;
 
     /**
-     * Returns the actual name of a given table name.
-     *
-     * This method will strip off curly brackets from the given table name and replace the percentage character '%' with
-     * {@see ConnectionInterface::tablePrefix}.
-     *
-     * @param string $name The table name to convert.
-     *
-     * @return string The real name of the given table name.
-     *
-     * @deprecated Use {@see Quoter::getRawTableName()}. Will be removed in version 2.0.0.
-     */
-    public function getRawTableName(string $name): string;
-
-    /**
      * Returns all schema names in the database, except system schemas.
      *
      * @param bool $refresh Whether to fetch the latest available schema names. If this is `false`, schema names fetched


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #767
