### PR TITLE
Move index type constants to `IndexType` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 - Enh #919: Replace `name()` with immutable `withName()` method in `ColumnInterface` interface (@Tigrov)
 - Enh #921: Move `DataType` class to `Yiisoft\Db\Constant` namespace (@Tigrov)
 - Enh #926: Refactor `DbArrayHelper` (@Tigrov)
+- Enh #920: Move index constants to the appropriate DBMS driver's `IndexType` and `IndexMethod` classes (@Tigrov) 
 
 ## 1.3.0 March 21, 2024
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -93,9 +93,10 @@ and the following changes were made:
 ### New classes with constants
 
 - `Yiisoft\Db\Constant\PhpType` with PHP types constants;
-- `Yiisoft\Db\Constant\GettypeResult` with `gettype()` function results constants.
-- `Yiisoft\Db\Constant\ColumnType` with abstract column types constants.
-- `Yiisoft\Db\Constant\PseudoType` with column pseudo-types constants.
+- `Yiisoft\Db\Constant\GettypeResult` with `gettype()` function results constants;
+- `Yiisoft\Db\Constant\ColumnType` with abstract column types constants;
+- `Yiisoft\Db\Constant\PseudoType` with column pseudo-types constants;
+- `Yiisoft\Db\Constant\IndexType` with table index types.
 
 ### New classes for table columns
 

--- a/src/Command/CommandInterface.php
+++ b/src/Command/CommandInterface.php
@@ -9,6 +9,7 @@ use JsonException;
 use Throwable;
 use Yiisoft\Db\Connection\ConnectionInterface;
 use Yiisoft\Db\Constant\ColumnType;
+use Yiisoft\Db\Constant\IndexType;
 use Yiisoft\Db\Constant\PseudoType;
 use Yiisoft\Db\Exception\Exception;
 use Yiisoft\Db\Exception\InvalidArgumentException;
@@ -296,12 +297,14 @@ interface CommandInterface
      * @param string $name The name of the index.
      * @param array|string $columns The column(s) to include in the index. If there are many columns,
      * separate them with commas.
-     * @param string|null $indexType The type of index-supported DBMS - for example: `UNIQUE`, `FULLTEXT`, `SPATIAL`,
-     * `BITMAP` or null as default.
-     * @param string|null $indexMethod The setting index organization method (with `USING`, not all DBMS).
+     * @param string|null $indexType The type of the index supported by DBMS {@see IndexType} - for example: `UNIQUE`,
+     * `FULLTEXT`, `SPATIAL`, `BITMAP` or null as default.
+     * @param string|null $indexMethod The index organization method (with `USING`, not all DBMS).
      *
      * @throws Exception
      * @throws InvalidArgumentException
+     *
+     * @psalm-param IndexType::*|null $indexType
      *
      * Note: The method will quote the `name`, `table`, and `column` parameters before using them in the generated SQL.
      */

--- a/src/Constant/IndexType.php
+++ b/src/Constant/IndexType.php
@@ -5,74 +5,13 @@ declare(strict_types=1);
 namespace Yiisoft\Db\Constant;
 
 /**
- * Defines the available index types. It is used in {@see DDLQueryBuilderInterface::createIndex()}.
+ * Defines the available index types for {@see DDLQueryBuilderInterface::createIndex()} method.
+ * Use driver specific implementations for other supported types if any.
  */
 final class IndexType
 {
     /**
      * Define the type of the index as `UNIQUE`.
-     *
-     * Supported by `MySQL`, `MariaDB`, `MSSQL`, `Oracle`, `PostgreSQL`, `SQLite`.
      */
     public const UNIQUE = 'UNIQUE';
-    /**
-     * Define the type of the index as `BTREE`.
-     *
-     * Supported by `MySQL`, `PostgreSQL`.
-     */
-    public const BTREE = 'BTREE';
-    /**
-     * Define the type of the index as `HASH`.
-     *
-     * Supported by `MySQL`, `PostgreSQL`.
-     */
-    public const HASH = 'HASH';
-    /**
-     * Define the type of the index as `FULLTEXT`.
-     *
-     * Supported by `MySQL`.
-     */
-    public const FULLTEXT = 'FULLTEXT';
-    /**
-     * Define the type of the index as `SPATIAL`.
-     *
-     * Supported by `MySQL`.
-     */
-    public const SPATIAL = 'SPATIAL';
-    /**
-     * Define the type of the index as `GIST`.
-     *
-     * Supported by `PostgreSQL`.
-     */
-    public const GIST = 'GIST';
-    /**
-     * Define the type of the index as `GIN`.
-     *
-     * Supported by `PostgreSQL`.
-     */
-    public const GIN = 'GIN';
-    /**
-     * Define the type of the index as `BRIN`.
-     *
-     * Supported by `PostgreSQL`.
-     */
-    public const BRIN = 'BRIN';
-    /**
-     * Define the type of the index as `CLUSTERED`.
-     *
-     * Supported by `MSSQL`.
-     */
-    public const CLUSTERED = 'CLUSTERED';
-    /**
-     * Define the type of the index as `NONCLUSTERED`.
-     *
-     * Supported by `MSSQL`.
-     */
-    public const NONCLUSTERED = 'NONCLUSTERED';
-    /**
-     * Define the type of the index as `BITMAP`.
-     *
-     * Supported by `Oracle`.
-     */
-    public const BITMAP = 'BITMAP';
 }

--- a/src/Constant/IndexType.php
+++ b/src/Constant/IndexType.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Db\Constant;
+
+/**
+ * Defines the available index types. It is used in {@see DDLQueryBuilderInterface::createIndex()}.
+ */
+final class IndexType
+{
+    /**
+     * Define the type of the index as `UNIQUE`.
+     *
+     * Supported by `MySQL`, `MariaDB`, `MSSQL`, `Oracle`, `PostgreSQL`, `SQLite`.
+     */
+    public const UNIQUE = 'UNIQUE';
+    /**
+     * Define the type of the index as `BTREE`.
+     *
+     * Supported by `MySQL`, `PostgreSQL`.
+     */
+    public const BTREE = 'BTREE';
+    /**
+     * Define the type of the index as `HASH`.
+     *
+     * Supported by `MySQL`, `PostgreSQL`.
+     */
+    public const HASH = 'HASH';
+    /**
+     * Define the type of the index as `FULLTEXT`.
+     *
+     * Supported by `MySQL`.
+     */
+    public const FULLTEXT = 'FULLTEXT';
+    /**
+     * Define the type of the index as `SPATIAL`.
+     *
+     * Supported by `MySQL`.
+     */
+    public const SPATIAL = 'SPATIAL';
+    /**
+     * Define the type of the index as `GIST`.
+     *
+     * Supported by `PostgreSQL`.
+     */
+    public const GIST = 'GIST';
+    /**
+     * Define the type of the index as `GIN`.
+     *
+     * Supported by `PostgreSQL`.
+     */
+    public const GIN = 'GIN';
+    /**
+     * Define the type of the index as `BRIN`.
+     *
+     * Supported by `PostgreSQL`.
+     */
+    public const BRIN = 'BRIN';
+    /**
+     * Define the type of the index as `CLUSTERED`.
+     *
+     * Supported by `MSSQL`.
+     */
+    public const CLUSTERED = 'CLUSTERED';
+    /**
+     * Define the type of the index as `NONCLUSTERED`.
+     *
+     * Supported by `MSSQL`.
+     */
+    public const NONCLUSTERED = 'NONCLUSTERED';
+    /**
+     * Define the type of the index as `BITMAP`.
+     *
+     * Supported by `Oracle`.
+     */
+    public const BITMAP = 'BITMAP';
+}

--- a/src/QueryBuilder/DDLQueryBuilderInterface.php
+++ b/src/QueryBuilder/DDLQueryBuilderInterface.php
@@ -205,9 +205,10 @@ interface DDLQueryBuilderInterface
      * @param string $name The name of the index.
      * @param array|string $columns The column(s) to include in the index.
      * If there are many columns, separate them with commas or use an array to represent them.
-     * @param string|null $indexType The type of the index supported by DBMS {@see IndexType} - for example, `UNIQUE`,
-     * `FULLTEXT`, `SPATIAL`, `BITMAP` or `null` as default.
-     * @param string|null $indexMethod The index organization method (with `USING`, not all DBMS).
+     * @param string|null $indexType The index type, `UNIQUE` or a DBMS specific index type or `null` by default.
+     * See {@see IndexType} or driver specific `IndexType` class.
+     * @param string|null $indexMethod The index organization method, if supported by DBMS.
+     * See driver specific `IndexMethod` class.
      *
      * @throws Exception
      * @throws InvalidArgumentException

--- a/src/QueryBuilder/DDLQueryBuilderInterface.php
+++ b/src/QueryBuilder/DDLQueryBuilderInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Db\QueryBuilder;
 
+use Yiisoft\Db\Constant\IndexType;
 use Yiisoft\Db\Exception\Exception;
 use Yiisoft\Db\Exception\InvalidArgumentException;
 use Yiisoft\Db\Exception\InvalidConfigException;
@@ -204,14 +205,16 @@ interface DDLQueryBuilderInterface
      * @param string $name The name of the index.
      * @param array|string $columns The column(s) to include in the index.
      * If there are many columns, separate them with commas or use an array to represent them.
-     * @param string|null $indexType Type of index-supported DBMS - for example, `UNIQUE`, `FULLTEXT`, `SPATIAL`, `BITMAP` or
-     * `null` as default
-     * @param string|null $indexMethod For setting index organization method (with `USING`, not all DBMS)
+     * @param string|null $indexType The type of the index supported by DBMS {@see IndexType} - for example, `UNIQUE`,
+     * `FULLTEXT`, `SPATIAL`, `BITMAP` or `null` as default.
+     * @param string|null $indexMethod The index organization method (with `USING`, not all DBMS).
      *
      * @throws Exception
      * @throws InvalidArgumentException
      *
      * @return string The SQL statement for creating a new index.
+     *
+     * @psalm-param IndexType::*|null $indexType
      *
      * Note: The method will quote the `name`, `table`, and `column` parameters before using them in the generated SQL.
      */

--- a/src/Schema/SchemaInterface.php
+++ b/src/Schema/SchemaInterface.php
@@ -58,66 +58,88 @@ interface SchemaInterface extends ConstraintSchemaInterface
      * Define the type of the index as `UNIQUE`, it's used in {@see DDLQueryBuilderInterface::createIndex()}.
      *
      * Supported by `MySQL`, `MariaDB`, `MSSQL`, `Oracle`, `PostgreSQL`, `SQLite`.
+     *
+     * @deprecated Use {@see IndexType::UNIQUE} instead. Will be removed in 2.0.
      */
     public const INDEX_UNIQUE = 'UNIQUE';
     /**
      * Define the type of the index as `BTREE`, it's used in {@see DDLQueryBuilderInterface::createIndex()}.
      *
      * Supported by `MySQL`, `PostgreSQL`.
+     *
+     * @deprecated Use {@see IndexType::BTREE} instead. Will be removed in 2.0.
      */
     public const INDEX_BTREE = 'BTREE';
     /**
      * Define the type of the index as `HASH`, it's used in {@see DDLQueryBuilderInterface::createIndex()}.
      *
      * Supported by `MySQL`, `PostgreSQL`.
+     *
+     * @deprecated Use {@see IndexType::HASH} instead. Will be removed in 2.0.
      */
     public const INDEX_HASH = 'HASH';
     /**
      * Define the type of the index as `FULLTEXT`, it's used in {@see DDLQueryBuilderInterface::createIndex()}.
      *
      * Supported by `MySQL`.
+     *
+     * @deprecated Use {@see IndexType::FULLTEXT} instead. Will be removed in 2.0.
      */
     public const INDEX_FULLTEXT = 'FULLTEXT';
     /**
      * Define the type of the index as `SPATIAL`, it's used in {@see DDLQueryBuilderInterface::createIndex()}.
      *
      * Supported by `MySQL`.
+     *
+     * @deprecated Use {@see IndexType::SPATIAL} instead. Will be removed in 2.0.
      */
     public const INDEX_SPATIAL = 'SPATIAL';
     /**
      * Define the type of the index as `GIST`, it's used in {@see DDLQueryBuilderInterface::createIndex()}.
      *
      * Supported by `PostgreSQL`.
+     *
+     * @deprecated Use {@see IndexType::GIST} instead. Will be removed in 2.0.
      */
     public const INDEX_GIST = 'GIST';
     /**
      * Define the type of the index as `GIN`, it's used in {@see DDLQueryBuilderInterface::createIndex()}.
      *
      * Supported by `PostgreSQL`.
+     *
+     * @deprecated Use {@see IndexType::GIN} instead. Will be removed in 2.0.
      */
     public const INDEX_GIN = 'GIN';
     /**
      * Define the type of the index as `BRIN`, it's used in {@see DDLQueryBuilderInterface::createIndex()}.
      *
      * Supported by `PostgreSQL`.
+     *
+     * @deprecated Use {@see IndexType::BRIN} instead. Will be removed in 2.0.
      */
     public const INDEX_BRIN = 'BRIN';
     /**
      * Define the type of the index as `CLUSTERED`, it's used in {@see DDLQueryBuilderInterface::createIndex()}.
      *
      * Supported by `MSSQL`.
+     *
+     * @deprecated Use {@see IndexType::CLUSTERED} instead. Will be removed in 2.0.
      */
     public const INDEX_CLUSTERED = 'CLUSTERED';
     /**
      * Define the type of the index as `NONCLUSTERED`, it's used in {@see DDLQueryBuilderInterface::createIndex()}.
      *
      * Supported by `MSSQL`.
+     *
+     * @deprecated Use {@see IndexType::NONCLUSTERED} instead. Will be removed in 2.0.
      */
     public const INDEX_NONCLUSTERED = 'NONCLUSTERED';
     /**
      * Define the type of the index as `BITMAP`, it's used in {@see DDLQueryBuilderInterface::createIndex()}.
      *
      * Supported by `Oracle`.
+     *
+     * @deprecated Use {@see IndexType::BITMAP} instead. Will be removed in 2.0.
      */
     public const INDEX_BITMAP = 'BITMAP';
     /**

--- a/src/Schema/SchemaInterface.php
+++ b/src/Schema/SchemaInterface.php
@@ -99,7 +99,7 @@ interface SchemaInterface extends ConstraintSchemaInterface
      *
      * Supported by `PostgreSQL`.
      *
-     * @deprecated Use {@see IndexType::GIST} instead. Will be removed in 2.0.
+     * @deprecated Use {@see IndexMethod::GIST} instead. Will be removed in 2.0.
      */
     public const INDEX_GIST = 'GIST';
     /**
@@ -107,7 +107,7 @@ interface SchemaInterface extends ConstraintSchemaInterface
      *
      * Supported by `PostgreSQL`.
      *
-     * @deprecated Use {@see IndexType::GIN} instead. Will be removed in 2.0.
+     * @deprecated Use {@see IndexMethod::GIN} instead. Will be removed in 2.0.
      */
     public const INDEX_GIN = 'GIN';
     /**
@@ -115,7 +115,7 @@ interface SchemaInterface extends ConstraintSchemaInterface
      *
      * Supported by `PostgreSQL`.
      *
-     * @deprecated Use {@see IndexType::BRIN} instead. Will be removed in 2.0.
+     * @deprecated Use {@see IndexMethod::BRIN} instead. Will be removed in 2.0.
      */
     public const INDEX_BRIN = 'BRIN';
     /**

--- a/tests/Common/CommonCommandTest.php
+++ b/tests/Common/CommonCommandTest.php
@@ -33,6 +33,7 @@ use Yiisoft\Db\Tests\Provider\CommandProvider;
 use Yiisoft\Db\Tests\Support\Assert;
 use Yiisoft\Db\Transaction\TransactionInterface;
 
+use function array_filter;
 use function is_string;
 use function setlocale;
 use function str_starts_with;
@@ -511,10 +512,9 @@ abstract class CommonCommandTest extends AbstractCommandTest
 
         $this->assertCount($count + 1, $schema->getTableIndexes($tableName));
 
-        $index = $schema->getTableIndexes($tableName)[$count];
+        $index = array_filter($schema->getTableIndexes($tableName), static fn ($index) => !$index->isPrimary())[0];
 
         $this->assertSame($indexColumns, $index->getColumnNames());
-        $this->assertFalse($index->isPrimary());
 
         if ($indexType !== null && str_starts_with($indexType, 'UNIQUE')) {
             $this->assertTrue($index->isUnique());

--- a/tests/Common/CommonCommandTest.php
+++ b/tests/Common/CommonCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Db\Tests\Common;
 
+use PHPUnit\Framework\Attributes\DataProviderExternal;
 use ReflectionException;
 use Throwable;
 use Yiisoft\Db\Constant\DataType;
@@ -28,11 +29,13 @@ use Yiisoft\Db\Query\Query;
 use Yiisoft\Db\QueryBuilder\QueryBuilderInterface;
 use Yiisoft\Db\Schema\Column\ColumnBuilder;
 use Yiisoft\Db\Tests\AbstractCommandTest;
+use Yiisoft\Db\Tests\Provider\CommandProvider;
 use Yiisoft\Db\Tests\Support\Assert;
 use Yiisoft\Db\Transaction\TransactionInterface;
 
 use function is_string;
 use function setlocale;
+use function str_starts_with;
 
 abstract class CommonCommandTest extends AbstractCommandTest
 {
@@ -486,45 +489,37 @@ abstract class CommonCommandTest extends AbstractCommandTest
         $db->close();
     }
 
-    /**
-     * @dataProvider \Yiisoft\Db\Tests\Provider\CommandProvider::createIndex
-     *
-     * @throws Exception
-     * @throws InvalidConfigException
-     * @throws Throwable
-     */
-    public function testCreateIndex(
-        string $name,
-        string $tableName,
-        array|string $column,
-        string|null $indexType,
-        string|null $indexMethod,
-    ): void {
+    #[DataProviderExternal(CommandProvider::class, 'createIndex')]
+    public function testCreateIndex(array $columns, array $indexColumns, string|null $indexType, string|null $indexMethod): void
+    {
         $db = $this->getConnection();
 
         $command = $db->createCommand();
         $schema = $db->getSchema();
 
+        $tableName = 'test_create_index';
+        $indexName = 'test_index_name';
+
         if ($schema->getTableSchema($tableName) !== null) {
             $command->dropTable($tableName)->execute();
         }
 
-        $command->createTable($tableName, ['int1' => 'integer not null', 'int2' => 'integer not null'])->execute();
+        $command->createTable($tableName, $columns)->execute();
 
-        $this->assertEmpty($schema->getTableIndexes($tableName, true));
+        $count = count($schema->getTableIndexes($tableName));
+        $command->createIndex($tableName, $indexName, $indexColumns, $indexType, $indexMethod)->execute();
 
-        $command->createIndex($tableName, $name, $column, $indexType, $indexMethod)->execute();
+        $this->assertCount($count + 1, $schema->getTableIndexes($tableName));
 
-        if (is_string($column)) {
-            $column = [$column];
-        }
+        $index = $schema->getTableIndexes($tableName)[$count];
 
-        $this->assertSame($column, $schema->getTableIndexes($tableName, true)[0]->getColumnNames());
+        $this->assertSame($indexColumns, $index->getColumnNames());
+        $this->assertFalse($index->isPrimary());
 
-        if ($indexType === 'UNIQUE') {
-            $this->assertTrue($schema->getTableIndexes($tableName, true)[0]->isUnique());
+        if ($indexType !== null && str_starts_with($indexType, 'UNIQUE')) {
+            $this->assertTrue($index->isUnique());
         } else {
-            $this->assertFalse($schema->getTableIndexes($tableName, true)[0]->isUnique());
+            $this->assertFalse($index->isUnique());
         }
 
         $db->close();

--- a/tests/Common/CommonSchemaTest.php
+++ b/tests/Common/CommonSchemaTest.php
@@ -19,7 +19,6 @@ use Yiisoft\Db\Exception\Exception;
 use Yiisoft\Db\Exception\InvalidCallException;
 use Yiisoft\Db\Exception\InvalidConfigException;
 use Yiisoft\Db\Exception\NotSupportedException;
-use Yiisoft\Db\Schema\SchemaInterface;
 use Yiisoft\Db\Schema\TableSchemaInterface;
 use Yiisoft\Db\Tests\AbstractSchemaTest;
 use Yiisoft\Db\Tests\Support\AnyCaseValue;

--- a/tests/Common/CommonSchemaTest.php
+++ b/tests/Common/CommonSchemaTest.php
@@ -9,6 +9,7 @@ use PDO;
 use Throwable;
 use Yiisoft\Db\Connection\ConnectionInterface;
 use Yiisoft\Db\Constant\ColumnType;
+use Yiisoft\Db\Constant\IndexType;
 use Yiisoft\Db\Constraint\CheckConstraint;
 use Yiisoft\Db\Constraint\Constraint;
 use Yiisoft\Db\Constraint\DefaultValueConstraint;
@@ -147,7 +148,7 @@ abstract class CommonSchemaTest extends AbstractSchemaTest
             'uniqueIndex',
             'somecolUnique',
             'somecol',
-            SchemaInterface::INDEX_UNIQUE,
+            IndexType::UNIQUE,
         )->execute();
         $tableSchema = $schema->getTableSchema('uniqueIndex', true);
 
@@ -166,7 +167,7 @@ abstract class CommonSchemaTest extends AbstractSchemaTest
             'uniqueIndex',
             'someCol2Unique',
             'someCol2',
-            SchemaInterface::INDEX_UNIQUE,
+            IndexType::UNIQUE,
         )->execute();
         $tableSchema = $schema->getTableSchema('uniqueIndex', true);
 
@@ -181,7 +182,7 @@ abstract class CommonSchemaTest extends AbstractSchemaTest
             'uniqueIndex',
             'another unique index',
             'someCol3',
-            SchemaInterface::INDEX_UNIQUE,
+            IndexType::UNIQUE,
         )->execute();
         $tableSchema = $schema->getTableSchema('uniqueIndex', true);
 

--- a/tests/Provider/CommandProvider.php
+++ b/tests/Provider/CommandProvider.php
@@ -14,7 +14,6 @@ use Yiisoft\Db\Constant\IndexType;
 use Yiisoft\Db\Expression\Expression;
 use Yiisoft\Db\Query\Query;
 use Yiisoft\Db\Schema\Column\ColumnBuilder;
-use Yiisoft\Db\Schema\SchemaInterface;
 use Yiisoft\Db\Tests\Support\DbHelper;
 use Yiisoft\Db\Tests\Support\Stringable;
 use Yiisoft\Db\Tests\Support\TestTrait;

--- a/tests/Provider/CommandProvider.php
+++ b/tests/Provider/CommandProvider.php
@@ -511,9 +511,9 @@ class CommandProvider
     public static function createIndex(): array
     {
         return [
-            ['{{test_idx_constraint_1}}', '{{test_idx}}', 'int1', null, null],
-            ['{{test_idx_constraint_2}}', '{{test_idx}}', ['int1'], IndexType::UNIQUE, null],
-            ['{{test_idx_constraint_3}}', '{{test_idx}}', ['int1', 'int2'], null, null],
+            [['col1' => ColumnBuilder::integer()], ['col1'], null, null],
+            [['col1' => ColumnBuilder::integer()], ['col1'], IndexType::UNIQUE, null],
+            [['col1' => ColumnBuilder::integer(), 'col2' => ColumnBuilder::integer()], ['col1', 'col2'], null, null],
         ];
     }
 

--- a/tests/Provider/CommandProvider.php
+++ b/tests/Provider/CommandProvider.php
@@ -10,6 +10,7 @@ use Traversable;
 use Yiisoft\Db\Command\DataType;
 use Yiisoft\Db\Command\Param;
 use Yiisoft\Db\Constant\ColumnType;
+use Yiisoft\Db\Constant\IndexType;
 use Yiisoft\Db\Expression\Expression;
 use Yiisoft\Db\Query\Query;
 use Yiisoft\Db\Schema\Column\ColumnBuilder;
@@ -512,7 +513,7 @@ class CommandProvider
     {
         return [
             ['{{test_idx_constraint_1}}', '{{test_idx}}', 'int1', null, null],
-            ['{{test_idx_constraint_2}}', '{{test_idx}}', ['int1'], SchemaInterface::INDEX_UNIQUE, null],
+            ['{{test_idx_constraint_2}}', '{{test_idx}}', ['int1'], IndexType::UNIQUE, null],
             ['{{test_idx_constraint_3}}', '{{test_idx}}', ['int1', 'int2'], null, null],
         ];
     }
@@ -550,7 +551,7 @@ class CommandProvider
                 '{{name}}',
                 '{{table}}',
                 ['column1', 'column2'],
-                SchemaInterface::INDEX_UNIQUE,
+                IndexType::UNIQUE,
                 '',
                 DbHelper::replaceQuotes(
                     <<<SQL

--- a/tests/Provider/QueryBuilderProvider.php
+++ b/tests/Provider/QueryBuilderProvider.php
@@ -8,6 +8,7 @@ use ArrayIterator;
 use Yiisoft\Db\Command\DataType;
 use Yiisoft\Db\Command\Param;
 use Yiisoft\Db\Constant\ColumnType;
+use Yiisoft\Db\Constant\IndexType;
 use Yiisoft\Db\Constant\PseudoType;
 use Yiisoft\Db\Constraint\ForeignKeyConstraint;
 use Yiisoft\Db\Expression\Expression;
@@ -936,7 +937,7 @@ class QueryBuilderProvider
                     $tableName,
                     $name1,
                     'C_index_1',
-                    SchemaInterface::INDEX_UNIQUE,
+                    IndexType::UNIQUE,
                 ),
             ],
             'create unique (2 columns)' => [
@@ -947,7 +948,7 @@ class QueryBuilderProvider
                     $tableName,
                     $name2,
                     'C_index_2_1, C_index_2_2',
-                    SchemaInterface::INDEX_UNIQUE,
+                    IndexType::UNIQUE,
                 ),
             ],
         ];

--- a/tests/Provider/QueryBuilderProvider.php
+++ b/tests/Provider/QueryBuilderProvider.php
@@ -19,7 +19,6 @@ use Yiisoft\Db\QueryBuilder\Condition\InCondition;
 use Yiisoft\Db\QueryBuilder\Condition\LikeCondition;
 use Yiisoft\Db\QueryBuilder\QueryBuilderInterface;
 use Yiisoft\Db\Schema\Column\ColumnBuilder;
-use Yiisoft\Db\Schema\SchemaInterface;
 use Yiisoft\Db\Tests\Support\DbHelper;
 use Yiisoft\Db\Tests\Support\Stringable;
 use Yiisoft\Db\Tests\Support\TestTrait;

--- a/tests/Provider/SchemaProvider.php
+++ b/tests/Provider/SchemaProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Db\Tests\Provider;
 
 use PDO;
+use Yiisoft\Db\Constant\IndexType;
 use Yiisoft\Db\Constraint\CheckConstraint;
 use Yiisoft\Db\Constraint\Constraint;
 use Yiisoft\Db\Constraint\ForeignKeyConstraint;
@@ -190,7 +191,7 @@ class SchemaProvider
     {
         return [
             [
-                'indexType' => SchemaInterface::INDEX_UNIQUE,
+                'indexType' => IndexType::UNIQUE,
                 'indexMethod' => null,
                 'columnType' => null,
                 'isPrimary' => false,


### PR DESCRIPTION
### Related PRs
- https://github.com/yiisoft/db-mysql/pull/374
- https://github.com/yiisoft/db-pgsql/pull/384
- https://github.com/yiisoft/db-mssql/pull/339
- https://github.com/yiisoft/db-oracle/pull/301
- https://github.com/yiisoft/db-migration/pull/285

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 