### PR TITLE
Remove `yiisoft/json` from `require-dev` section of `composer.json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 - Bug #933: Explicitly mark nullable parameters (@vjik)
 - Chg #911: Change supported PHP versions to `8.1 - 8.4` (@Tigrov)
 - Enh #911: Minor refactoring (@Tigrov)
+- Chg #938: Remove `ext-json` from `require` section of `composer.json` (@Tigrov) 
 
 ## 1.3.0 March 21, 2024
 

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,6 @@
         "yiisoft/cache-file": "^3.2",
         "yiisoft/di": "^1.3",
         "yiisoft/event-dispatcher": "^1.1",
-        "yiisoft/json": "^1.0",
         "yiisoft/log": "^2.1",
         "yiisoft/var-dumper": "^1.7",
         "yiisoft/yii-debug": "dev-master"

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,6 @@
     "require": {
         "php": "8.1 - 8.4",
         "ext-ctype": "*",
-        "ext-json": "*",
         "ext-mbstring": "*",
         "ext-pdo": "*",
         "psr/log": "^2.0|^3.0",


### PR DESCRIPTION
### Related PRs
- https://github.com/yiisoft/db-sqlite/pull/343
- https://github.com/yiisoft/db-mysql/pull/382
- https://github.com/yiisoft/db-pgsql/pull/390
- https://github.com/yiisoft/active-record/pull/406

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 