### PR TITLE
Refactofing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,10 +64,12 @@
 - Enh #929: Implement lazy arrays for array, structured and JSON column types (@Tigrov)
 - Bug #933: Explicitly mark nullable parameters (@vjik)
 - Chg #911: Change supported PHP versions to `8.1 - 8.4` (@Tigrov)
-- Enh #911: Minor refactoring (@Tigrov)
+- Enh #911, #940: Minor refactoring (@Tigrov)
 - Chg #938, #936, #937: Remove `ext-json`, `ext-ctype`, `ext-mbstring` from `require` section of `composer.json` (@Tigrov) 
 - Chg #936: Remove `hasLimit()` and `hasOffset()` methods from `AbstractDQLQueryBuilder` class (@Tigrov)
 - Chg #937: Remove `baseName()` and `pascalCaseToId()` methods from `DbStringHelper` (@Tigrov)
+- Enh #940: Rename `quoter()` method to `getQuoter()` in `QueryBuilderInterface` and `AbstractQueryBuilder` class (@Tigrov)
+- Enh #940: Change constructor parameters in `AbstractQueryBuilder` class (@Tigrov)
 
 ## 1.3.0 March 21, 2024
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -117,12 +117,13 @@ Each table column has its own class in the `Yiisoft\Db\Schema\Column` namespace 
 ### New methods
 
 - `QuoterInterface::getRawTableName()` - returns the raw table name without quotes;
-- `SchemaInterface::getColumnFactory()` - returns the column factory object for concrete DBMS;
+- `ConnectionInterface::getColumnFactory()` - returns the column factory object for concrete DBMS;
+- `ConnectionInterface::getServerInfo()` - returns `ServerInfoInterface` instance which provides server information;
 - `QueryBuilderInterface::buildColumnDefinition()` - builds column definition for `CREATE TABLE` statement;
 - `QueryBuilderInterface::prepareParam()` - converts a `ParamInterface` object to its SQL representation;
 - `QueryBuilderInterface::prepareValue()` - converts a value to its SQL representation;
+- `QueryBuilderInterface::getColumnFactory()` - returns the column factory object for concrete DBMS;
 - `QueryBuilderInterface::getServerInfo()` - returns `ServerInfoInterface` instance which provides server information;
-- `ConnectionInterface::getServerInfo()` - returns `ServerInfoInterface` instance which provides server information;
 
 ### Remove methods
 
@@ -178,3 +179,5 @@ Each table column has its own class in the `Yiisoft\Db\Schema\Column` namespace 
 - Change `DbArrayHelper::index()` parameter names and allow to accept `Closure` for `$indexBy` parameter; 
 - Change return type of `CommandInterface::insertWithReturningPks()` method to `array|false`;
 - Change return type of `AbstractCommand::insertWithReturningPks()` method to `array|false`;
+- Rename `QueryBuilderInterface::quoter()` method to `QueryBuilderInterface::getQuoter()`;
+- Change constructor parameters in `AbstractQueryBuilder` class;

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -208,7 +208,7 @@ abstract class AbstractCommand implements CommandInterface
 
     public function insertBatch(string $table, iterable $rows, array $columns = []): static
     {
-        $table = $this->getQueryBuilder()->quoter()->getRawTableName($table);
+        $table = $this->getQueryBuilder()->getQuoter()->getRawTableName($table);
 
         $params = [];
         $sql = $this->getQueryBuilder()->insertBatch($table, $rows, $columns, $params);
@@ -489,7 +489,7 @@ abstract class AbstractCommand implements CommandInterface
     {
         $this->cancel();
         $this->reset();
-        $this->sql = $this->getQueryBuilder()->quoter()->quoteSql($sql);
+        $this->sql = $this->getQueryBuilder()->getQuoter()->quoteSql($sql);
         return $this;
     }
 

--- a/src/Connection/ConnectionInterface.php
+++ b/src/Connection/ConnectionInterface.php
@@ -14,6 +14,7 @@ use Yiisoft\Db\Exception\NotSupportedException;
 use Yiisoft\Db\Query\BatchQueryResultInterface;
 use Yiisoft\Db\Query\QueryInterface;
 use Yiisoft\Db\QueryBuilder\QueryBuilderInterface;
+use Yiisoft\Db\Schema\Column\ColumnFactoryInterface;
 use Yiisoft\Db\Schema\QuoterInterface;
 use Yiisoft\Db\Schema\SchemaInterface;
 use Yiisoft\Db\Schema\TableSchemaInterface;
@@ -84,6 +85,11 @@ interface ConnectionInterface
      * It does nothing if the connection is already closed.
      */
     public function close(): void;
+
+    /**
+     * Returns the column factory for creating column instances.
+     */
+    public function getColumnFactory(): ColumnFactoryInterface;
 
     /**
      * Returns the name of the DB driver for the current `dsn`.

--- a/src/Debug/ConnectionInterfaceProxy.php
+++ b/src/Debug/ConnectionInterfaceProxy.php
@@ -11,6 +11,7 @@ use Yiisoft\Db\Connection\ServerInfoInterface;
 use Yiisoft\Db\Query\BatchQueryResultInterface;
 use Yiisoft\Db\Query\QueryInterface;
 use Yiisoft\Db\QueryBuilder\QueryBuilderInterface;
+use Yiisoft\Db\Schema\Column\ColumnFactoryInterface;
 use Yiisoft\Db\Schema\QuoterInterface;
 use Yiisoft\Db\Schema\SchemaInterface;
 use Yiisoft\Db\Schema\TableSchemaInterface;
@@ -61,6 +62,11 @@ final class ConnectionInterfaceProxy implements ConnectionInterface
     public function close(): void
     {
         $this->connection->close();
+    }
+
+    public function getColumnFactory(): ColumnFactoryInterface
+    {
+        return $this->connection->getColumnFactory();
     }
 
     public function getLastInsertID(?string $sequenceName = null): string

--- a/src/QueryBuilder/AbstractColumnDefinitionBuilder.php
+++ b/src/QueryBuilder/AbstractColumnDefinitionBuilder.php
@@ -230,7 +230,7 @@ abstract class AbstractColumnDefinitionBuilder implements ColumnDefinitionBuilde
             return null;
         }
 
-        $quoter = $this->queryBuilder->quoter();
+        $quoter = $this->queryBuilder->getQuoter();
         $schema = $reference?->getForeignSchemaName();
 
         $sql = $quoter->quoteTableName($table);

--- a/src/QueryBuilder/Condition/Builder/AbstractOverlapsConditionBuilder.php
+++ b/src/QueryBuilder/Condition/Builder/AbstractOverlapsConditionBuilder.php
@@ -23,6 +23,6 @@ abstract class AbstractOverlapsConditionBuilder implements ExpressionBuilderInte
             return $this->queryBuilder->buildExpression($column);
         }
 
-        return $this->queryBuilder->quoter()->quoteColumnName($column);
+        return $this->queryBuilder->getQuoter()->quoteColumnName($column);
     }
 }

--- a/src/QueryBuilder/Condition/Builder/BetweenColumnsConditionBuilder.php
+++ b/src/QueryBuilder/Condition/Builder/BetweenColumnsConditionBuilder.php
@@ -81,7 +81,7 @@ class BetweenColumnsConditionBuilder implements ExpressionBuilderInterface
         }
 
         if (!str_contains($columnName, '(')) {
-            return $this->queryBuilder->quoter()->quoteColumnName($columnName);
+            return $this->queryBuilder->getQuoter()->quoteColumnName($columnName);
         }
 
         return $columnName;

--- a/src/QueryBuilder/Condition/Builder/BetweenConditionBuilder.php
+++ b/src/QueryBuilder/Condition/Builder/BetweenConditionBuilder.php
@@ -39,7 +39,7 @@ class BetweenConditionBuilder implements ExpressionBuilderInterface
         $column = $column instanceof ExpressionInterface ? $this->queryBuilder->buildExpression($column) : $column;
 
         if (!str_contains($column, '(')) {
-            $column = $this->queryBuilder->quoter()->quoteColumnName($column);
+            $column = $this->queryBuilder->getQuoter()->quoteColumnName($column);
         }
 
         $phName1 = $this->createPlaceholder($expression->getIntervalStart(), $params);

--- a/src/QueryBuilder/Condition/Builder/HashConditionBuilder.php
+++ b/src/QueryBuilder/Condition/Builder/HashConditionBuilder.php
@@ -51,7 +51,7 @@ class HashConditionBuilder implements ExpressionBuilderInterface
                 $parts[] = $this->queryBuilder->buildCondition(new InCondition($column, 'IN', $value), $params);
             } else {
                 if (!str_contains($column, '(')) {
-                    $column = $this->queryBuilder->quoter()->quoteColumnName($column);
+                    $column = $this->queryBuilder->getQuoter()->quoteColumnName($column);
                 }
 
                 if ($value === null) {

--- a/src/QueryBuilder/Condition/Builder/InConditionBuilder.php
+++ b/src/QueryBuilder/Condition/Builder/InConditionBuilder.php
@@ -110,7 +110,7 @@ class InConditionBuilder implements ExpressionBuilderInterface
         }
 
         if (is_string($column) && !str_contains($column, '(')) {
-            $column = $this->queryBuilder->quoter()->quoteColumnName($column);
+            $column = $this->queryBuilder->getQuoter()->quoteColumnName($column);
         }
 
         if (count($sqlValues) > 1) {
@@ -205,7 +205,7 @@ class InConditionBuilder implements ExpressionBuilderInterface
                 }
 
                 if (!str_contains($col, '(')) {
-                    $columns[$i] = $this->queryBuilder->quoter()->quoteColumnName($col);
+                    $columns[$i] = $this->queryBuilder->getQuoter()->quoteColumnName($col);
                 }
             }
 
@@ -213,7 +213,7 @@ class InConditionBuilder implements ExpressionBuilderInterface
         }
 
         if (is_string($columns) && !str_contains($columns, '(')) {
-            $columns = $this->queryBuilder->quoter()->quoteColumnName($columns);
+            $columns = $this->queryBuilder->getQuoter()->quoteColumnName($columns);
             $query = "$columns $operator $sql";
         }
 
@@ -268,7 +268,7 @@ class InConditionBuilder implements ExpressionBuilderInterface
             }
 
             $sqlColumns[] = !str_contains($column, '(')
-                ? $this->queryBuilder->quoter()->quoteColumnName($column) : $column;
+                ? $this->queryBuilder->getQuoter()->quoteColumnName($column) : $column;
         }
 
         return '(' . implode(', ', $sqlColumns) . ") $operator (" . implode(', ', $vss) . ')';
@@ -279,7 +279,7 @@ class InConditionBuilder implements ExpressionBuilderInterface
      */
     protected function getNullCondition(string $operator, string $column): string
     {
-        $column = $this->queryBuilder->quoter()->quoteColumnName($column);
+        $column = $this->queryBuilder->getQuoter()->quoteColumnName($column);
 
         if ($operator === 'IN') {
             return sprintf('%s IS NULL', $column);

--- a/src/QueryBuilder/Condition/Builder/LikeConditionBuilder.php
+++ b/src/QueryBuilder/Condition/Builder/LikeConditionBuilder.php
@@ -73,7 +73,7 @@ class LikeConditionBuilder implements ExpressionBuilderInterface
         if ($column instanceof ExpressionInterface) {
             $column = $this->queryBuilder->buildExpression($column, $params);
         } elseif (!str_contains($column, '(')) {
-            $column = $this->queryBuilder->quoter()->quoteColumnName($column);
+            $column = $this->queryBuilder->getQuoter()->quoteColumnName($column);
         }
 
         $parts = [];

--- a/src/QueryBuilder/Condition/Builder/SimpleConditionBuilder.php
+++ b/src/QueryBuilder/Condition/Builder/SimpleConditionBuilder.php
@@ -42,7 +42,7 @@ class SimpleConditionBuilder implements ExpressionBuilderInterface
         if ($column instanceof ExpressionInterface) {
             $column = $this->queryBuilder->buildExpression($column, $params);
         } elseif (!str_contains($column, '(')) {
-            $column = $this->queryBuilder->quoter()->quoteColumnName($column);
+            $column = $this->queryBuilder->getQuoter()->quoteColumnName($column);
         }
 
         if ($value === null) {

--- a/src/QueryBuilder/QueryBuilderInterface.php
+++ b/src/QueryBuilder/QueryBuilderInterface.php
@@ -10,9 +10,9 @@ use Yiisoft\Db\Connection\ServerInfoInterface;
 use Yiisoft\Db\Exception\InvalidArgumentException;
 use Yiisoft\Db\Expression\ExpressionBuilderInterface;
 use Yiisoft\Db\Expression\ExpressionInterface;
+use Yiisoft\Db\Schema\Column\ColumnFactoryInterface;
 use Yiisoft\Db\Schema\Column\ColumnInterface;
 use Yiisoft\Db\Schema\QuoterInterface;
-use Yiisoft\Db\Schema\SchemaInterface;
 
 /**
  * Defines the common interface to be implemented by query builder classes.
@@ -55,6 +55,11 @@ interface QueryBuilderInterface extends DDLQueryBuilderInterface, DMLQueryBuilde
     public function getColumnDefinitionBuilder(): ColumnDefinitionBuilderInterface;
 
     /**
+     * Returns the column factory for creating column instances.
+     */
+    public function getColumnFactory(): ColumnFactoryInterface;
+
+    /**
      * Gets an object of {@see ExpressionBuilderInterface} that's suitable for $expression.
      *
      * Uses {@see AbstractDQLQueryBuilder::expressionBuilders} an array to find a suitable builder class.
@@ -66,11 +71,6 @@ interface QueryBuilderInterface extends DDLQueryBuilderInterface, DMLQueryBuilde
     public function getExpressionBuilder(ExpressionInterface $expression): object;
 
     /**
-     * Returns {@see SchemaInterface} instance that provides information about the database schema.
-     */
-    public function getSchema(): SchemaInterface;
-
-    /**
      * Returns {@see ServerInfoInterface} instance that provides information about the database server.
      */
     public function getServerInfo(): ServerInfoInterface;
@@ -78,7 +78,7 @@ interface QueryBuilderInterface extends DDLQueryBuilderInterface, DMLQueryBuilde
     /**
      * @return QuoterInterface The quoter instance.
      */
-    public function quoter(): QuoterInterface;
+    public function getQuoter(): QuoterInterface;
 
     /**
      * Converts a {@see ParamInterface} object to its SQL representation and quotes it if necessary.

--- a/src/Schema/SchemaInterface.php
+++ b/src/Schema/SchemaInterface.php
@@ -300,11 +300,6 @@ interface SchemaInterface extends ConstraintSchemaInterface
     public const TYPE_JSON = 'json';
 
     /**
-     * Returns the column factory for creating column instances.
-     */
-    public function getColumnFactory(): ColumnFactoryInterface;
-
-    /**
      * @return string|null The default schema name.
      */
     public function getDefaultSchema(): string|null;

--- a/src/Schema/SchemaInterface.php
+++ b/src/Schema/SchemaInterface.php
@@ -12,7 +12,6 @@ use Yiisoft\Db\Constraint\ConstraintSchemaInterface;
 use Yiisoft\Db\Exception\Exception;
 use Yiisoft\Db\Exception\InvalidConfigException;
 use Yiisoft\Db\Exception\NotSupportedException;
-use Yiisoft\Db\Schema\Column\ColumnFactoryInterface;
 
 /**
  * Represents the schema for a database table.

--- a/tests/AbstractColumnFactoryTest.php
+++ b/tests/AbstractColumnFactoryTest.php
@@ -20,7 +20,7 @@ abstract class AbstractColumnFactoryTest extends TestCase
     public function testFromDbType(string $dbType, string $expectedType, string $expectedInstanceOf): void
     {
         $db = $this->getConnection();
-        $columnFactory = $db->getSchema()->getColumnFactory();
+        $columnFactory = $db->getColumnFactory();
 
         $column = $columnFactory->fromDbType($dbType);
 
@@ -35,7 +35,7 @@ abstract class AbstractColumnFactoryTest extends TestCase
     public function testFromDefinition(string $definition, ColumnInterface $expected): void
     {
         $db = $this->getConnection();
-        $columnFactory = $db->getSchema()->getColumnFactory();
+        $columnFactory = $db->getColumnFactory();
 
         $column = $columnFactory->fromDefinition($definition);
 
@@ -48,7 +48,7 @@ abstract class AbstractColumnFactoryTest extends TestCase
     public function testFromPseudoType(string $pseudoType, ColumnInterface $expected): void
     {
         $db = $this->getConnection();
-        $columnFactory = $db->getSchema()->getColumnFactory();
+        $columnFactory = $db->getColumnFactory();
 
         $column = $columnFactory->fromPseudoType($pseudoType);
 
@@ -61,7 +61,7 @@ abstract class AbstractColumnFactoryTest extends TestCase
     public function testFromType(string $type, string $expectedType, string $expectedInstanceOf): void
     {
         $db = $this->getConnection();
-        $columnFactory = $db->getSchema()->getColumnFactory();
+        $columnFactory = $db->getColumnFactory();
 
         $column = $columnFactory->fromType($type);
 
@@ -74,7 +74,7 @@ abstract class AbstractColumnFactoryTest extends TestCase
     public function testFromDefinitionWithExtra(): void
     {
         $db = $this->getConnection();
-        $columnFactory = $db->getSchema()->getColumnFactory();
+        $columnFactory = $db->getColumnFactory();
 
         $column = $columnFactory->fromDefinition('char(1) INVISIBLE', ['extra' => 'COLLATE utf8mb4']);
 
@@ -90,7 +90,7 @@ abstract class AbstractColumnFactoryTest extends TestCase
     public function testFromTypeDefaultValueRaw(string $type, string|null $defaultValueRaw, mixed $expected): void
     {
         $db = $this->getConnection();
-        $columnFactory = $db->getSchema()->getColumnFactory();
+        $columnFactory = $db->getColumnFactory();
 
         $column = $columnFactory->fromType($type, ['defaultValueRaw' => $defaultValueRaw]);
 
@@ -106,7 +106,7 @@ abstract class AbstractColumnFactoryTest extends TestCase
     public function testNullDefaultValueRaw(): void
     {
         $db = $this->getConnection();
-        $columnFactory = $db->getSchema()->getColumnFactory();
+        $columnFactory = $db->getColumnFactory();
 
         $column = $columnFactory->fromType(ColumnType::INTEGER, ['defaultValueRaw' => '1', 'primaryKey' => true]);
 

--- a/tests/AbstractQueryBuilderTest.php
+++ b/tests/AbstractQueryBuilderTest.php
@@ -1914,7 +1914,7 @@ abstract class AbstractQueryBuilderTest extends TestCase
 
         $qb = $db->getQueryBuilder();
 
-        $this->assertInstanceOf(QuoterInterface::class, $qb->quoter());
+        $this->assertInstanceOf(QuoterInterface::class, $qb->getQuoter());
     }
 
     public function testRenameColumn(): void
@@ -2254,7 +2254,7 @@ abstract class AbstractQueryBuilderTest extends TestCase
         $qb = $db->getQueryBuilder();
 
         $sql = $qb->update($table, $columns, $condition, $params);
-        $sql = $qb->quoter()->quoteSql($sql);
+        $sql = $db->getQuoter()->quoteSql($sql);
 
         $this->assertSame($expectedSql, $sql);
         $this->assertEquals($expectedParams, $params);

--- a/tests/Common/CommonPdoConnectionTest.php
+++ b/tests/Common/CommonPdoConnectionTest.php
@@ -345,6 +345,7 @@ abstract class CommonPdoConnectionTest extends AbstractPdoConnectionTest
         $db = $this->getMockBuilder(AbstractPdoConnection::class)->onlyMethods([
             'createCommand',
             'createTransaction',
+            'getColumnFactory',
             'getPdo',
             'getQueryBuilder',
             'getQuoter',

--- a/tests/Common/CommonQueryBuilderTest.php
+++ b/tests/Common/CommonQueryBuilderTest.php
@@ -22,8 +22,7 @@ abstract class CommonQueryBuilderTest extends AbstractQueryBuilderTest
     public function testCreateTableWithBuildColumnDefinition(): void
     {
         $db = $this->getConnection();
-        $schema = $db->getSchema();
-        $columnFactory = $schema->getColumnFactory();
+        $columnFactory = $db->getColumnFactory();
         $command = $db->createCommand();
 
         $provider = $this->getBuildColumnDefinitionProvider();

--- a/tests/Db/Command/CommandTest.php
+++ b/tests/Db/Command/CommandTest.php
@@ -187,13 +187,18 @@ final class CommandTest extends AbstractCommandTest
         $db = $this->getConnection();
 
         $command = $db->createCommand();
-
-        $this->expectException(NotSupportedException::class);
-        $this->expectExceptionMessage(
-            'Yiisoft\Db\Tests\Support\Stub\Schema::loadTableSchema is not supported by this DBMS.'
-        );
-
         $command->insertBatch('table', [['value1', 'value2'], ['value3', 'value4']], ['column1', 'column2']);
+
+        $this->assertSame('INSERT INTO [table] ([column1], [column2]) VALUES (:qp0, :qp1), (:qp2, :qp3)', $command->getSql());
+        $this->assertSame(
+            [
+                ':qp0' => 'value1',
+                ':qp1' => 'value2',
+                ':qp2' => 'value3',
+                ':qp3' => 'value4',
+            ],
+            $command->getParams()
+        );
     }
 
     /**
@@ -524,13 +529,20 @@ final class CommandTest extends AbstractCommandTest
         $db = $this->getConnection();
 
         $command = $db->createCommand();
-
-        $this->expectException(NotSupportedException::class);
-        $this->expectExceptionMessage(
-            'Yiisoft\Db\Tests\Support\Stub\Schema::loadTableSchema is not supported by this DBMS.'
-        );
-
         $command->insert('customer', ['email' => 't1@example.com', 'name' => 'test', 'address' => 'test address']);
+
+        $this->assertSame(
+            'INSERT INTO [customer] ([email], [name], [address]) VALUES (:qp0, :qp1, :qp2)',
+            $command->getSql(),
+        );
+        $this->assertSame(
+            [
+                ':qp0' => 't1@example.com',
+                ':qp1' => 'test',
+                ':qp2' => 'test address',
+            ],
+            $command->getParams(),
+        );
     }
 
     public function testQuery(): void
@@ -704,13 +716,10 @@ final class CommandTest extends AbstractCommandTest
         $db = $this->getConnection();
 
         $command = $db->createCommand();
+        $command->update('{{table}}', ['name' => 'John'], ['id' => 1]);
 
-        $this->expectException(NotSupportedException::class);
-        $this->expectExceptionMessage(
-            'Yiisoft\Db\Tests\Support\Stub\Schema::loadTableSchema is not supported by this DBMS.'
-        );
-
-        $command->update('{{table}}', [], [], []);
+        $this->assertSame('UPDATE [table] SET [name]=:qp0 WHERE [id]=:qp1', $command->getSql());
+        $this->assertSame([':qp0' => 'John', ':qp1' => 1], $command->getParams());
     }
 
     public function testUpsert(): void

--- a/tests/Db/Connection/ConnectionTest.php
+++ b/tests/Db/Connection/ConnectionTest.php
@@ -21,12 +21,7 @@ final class ConnectionTest extends AbstractConnectionTest
     {
         $db = $this->getConnection();
 
-        $this->expectException(NotSupportedException::class);
-        $this->expectExceptionMessage(
-            'Yiisoft\Db\Tests\Support\Stub\Schema::loadTableSchema is not supported by this DBMS.'
-        );
-
-        $db->getTableSchema('non_existing_table');
+        $this->assertNull($db->getTableSchema('non_existing_table'));
     }
 
     public function testSerialized(): void

--- a/tests/Db/QueryBuilder/QueryBuilderTest.php
+++ b/tests/Db/QueryBuilder/QueryBuilderTest.php
@@ -61,9 +61,7 @@ final class QueryBuilderTest extends AbstractQueryBuilderTest
         array $expectedParams = [],
     ): void {
         $db = $this->getConnection();
-
-        $schemaMock = $this->createMock(Schema::class);
-        $qb = new QueryBuilder($db->getQuoter(), $schemaMock, $db->getServerInfo());
+        $qb = new QueryBuilder($db);
         $params = [];
 
         try {
@@ -145,10 +143,8 @@ final class QueryBuilderTest extends AbstractQueryBuilderTest
     public function testCreateView(): void
     {
         $db = $this->getConnection();
-
-        $schemaMock = $this->createMock(Schema::class);
         $subQuery = (new Query($db))->select('{{bar}}')->from('{{testCreateViewTable}}')->where(['>', 'bar', '5']);
-        $qb = new QueryBuilder($db->getQuoter(), $schemaMock, $db->getServerInfo());
+        $qb = new QueryBuilder($db);
 
         $this->assertSame(
             <<<SQL
@@ -203,9 +199,7 @@ final class QueryBuilderTest extends AbstractQueryBuilderTest
         array $expectedParams
     ): void {
         $db = $this->getConnection();
-
-        $schemaMock = $this->createMock(Schema::class);
-        $qb = new QueryBuilder($db->getQuoter(), $schemaMock, $db->getServerInfo());
+        $qb = new QueryBuilder($db);
 
         $this->assertSame($expectedSQL, $qb->insert($table, $columns, $params));
         $this->assertEquals($expectedParams, $params);
@@ -264,12 +258,10 @@ final class QueryBuilderTest extends AbstractQueryBuilderTest
         array $expectedParams
     ): void {
         $db = $this->getConnection();
-
-        $schemaMock = $this->createMock(Schema::class);
-        $qb = new QueryBuilder($db->getQuoter(), $schemaMock, $db->getServerInfo());
+        $qb = $db->getQueryBuilder();
 
         $sql = $qb->update($table, $columns, $condition, $params);
-        $sql = $qb->quoter()->quoteSql($sql);
+        $sql = $db->getQuoter()->quoteSql($sql);
 
         $this->assertSame($expectedSql, $sql);
         $this->assertEquals($expectedParams, $params);

--- a/tests/Db/QueryBuilder/QueryBuilderTest.php
+++ b/tests/Db/QueryBuilder/QueryBuilderTest.php
@@ -17,7 +17,6 @@ use Yiisoft\Db\Schema\Column\ColumnBuilder;
 use Yiisoft\Db\Tests\AbstractQueryBuilderTest;
 use Yiisoft\Db\Tests\Support\DbHelper;
 use Yiisoft\Db\Tests\Support\Stub\QueryBuilder;
-use Yiisoft\Db\Tests\Support\Stub\Schema;
 use Yiisoft\Db\Tests\Support\TestTrait;
 
 use function fclose;

--- a/tests/Support/Stub/ColumnDefinitionBuilder.php
+++ b/tests/Support/Stub/ColumnDefinitionBuilder.php
@@ -44,7 +44,7 @@ final class ColumnDefinitionBuilder extends AbstractColumnDefinitionBuilder
             $columnName = $column->getName();
 
             if (!empty($columnName) && $column->getType() === ColumnType::JSON) {
-                return ' CHECK (json_valid(' . $this->queryBuilder->quoter()->quoteColumnName($columnName) . '))';
+                return ' CHECK (json_valid(' . $this->queryBuilder->getQuoter()->quoteColumnName($columnName) . '))';
             }
 
             return '';

--- a/tests/Support/Stub/Connection.php
+++ b/tests/Support/Stub/Connection.php
@@ -8,6 +8,7 @@ use PDO;
 use Yiisoft\Db\Command\CommandInterface;
 use Yiisoft\Db\Driver\Pdo\AbstractPdoConnection;
 use Yiisoft\Db\QueryBuilder\QueryBuilderInterface;
+use Yiisoft\Db\Schema\Column\ColumnFactoryInterface;
 use Yiisoft\Db\Schema\Quoter;
 use Yiisoft\Db\Schema\QuoterInterface;
 use Yiisoft\Db\Schema\SchemaInterface;
@@ -15,9 +16,6 @@ use Yiisoft\Db\Transaction\TransactionInterface;
 
 final class Connection extends AbstractPdoConnection
 {
-    protected QueryBuilderInterface|null $queryBuilder = null;
-    protected SchemaInterface|null $schema = null;
-
     public function createCommand(?string $sql = null, array $params = []): CommandInterface
     {
         $command = new Command($this);
@@ -42,35 +40,24 @@ final class Connection extends AbstractPdoConnection
         return new Transaction($this);
     }
 
+    public function getColumnFactory(): ColumnFactoryInterface
+    {
+        return new ColumnFactory();
+    }
+
     public function getQueryBuilder(): QueryBuilderInterface
     {
-        if ($this->queryBuilder === null) {
-            $this->queryBuilder = new QueryBuilder(
-                $this->getQuoter(),
-                $this->getSchema(),
-                $this->getServerInfo(),
-            );
-        }
-
-        return $this->queryBuilder;
+        return $this->queryBuilder ??= new QueryBuilder($this);
     }
 
     public function getQuoter(): QuoterInterface
     {
-        if ($this->quoter === null) {
-            $this->quoter = new Quoter(['[', ']'], ['[', ']'], $this->getTablePrefix());
-        }
-
-        return $this->quoter;
+        return $this->quoter ??= new Quoter(['[', ']'], ['[', ']'], $this->getTablePrefix());
     }
 
     public function getSchema(): SchemaInterface
     {
-        if ($this->schema === null) {
-            $this->schema = new Schema($this, $this->schemaCache);
-        }
-
-        return $this->schema;
+        return $this->schema ??= new Schema($this, $this->schemaCache);
     }
 
     protected function initConnection(): void

--- a/tests/Support/Stub/QueryBuilder.php
+++ b/tests/Support/Stub/QueryBuilder.php
@@ -4,19 +4,18 @@ declare(strict_types=1);
 
 namespace Yiisoft\Db\Tests\Support\Stub;
 
-use Yiisoft\Db\Connection\ServerInfoInterface;
+use Yiisoft\Db\Connection\ConnectionInterface;
 use Yiisoft\Db\QueryBuilder\AbstractQueryBuilder;
-use Yiisoft\Db\Schema\QuoterInterface;
-use Yiisoft\Db\Schema\SchemaInterface;
 
 final class QueryBuilder extends AbstractQueryBuilder
 {
-    public function __construct(QuoterInterface $quoter, SchemaInterface $schema, ServerInfoInterface $serverInfo)
+    public function __construct(ConnectionInterface $db)
     {
+        $quoter = $db->getQuoter();
+        $schema = $db->getSchema();
+
         parent::__construct(
-            $quoter,
-            $schema,
-            $serverInfo,
+            $db,
             new DDLQueryBuilder($this, $quoter, $schema),
             new DMLQueryBuilder($this, $quoter, $schema),
             new DQLQueryBuilder($this, $quoter),

--- a/tests/Support/Stub/Schema.php
+++ b/tests/Support/Stub/Schema.php
@@ -17,11 +17,6 @@ use Yiisoft\Db\Schema\TableSchemaInterface;
  */
 class Schema extends AbstractSchema
 {
-    public function getColumnFactory(): ColumnFactoryInterface
-    {
-        return new ColumnFactory();
-    }
-
     public function findUniqueIndexes(TableSchemaInterface $table): array
     {
         throw new NotSupportedException(__METHOD__ . ' is not supported by this DBMS.');
@@ -93,11 +88,8 @@ class Schema extends AbstractSchema
         throw new NotSupportedException(__METHOD__ . ' is not supported by this DBMS.');
     }
 
-    /**
-     * @throws NotSupportedException
-     */
     protected function loadTableSchema(string $name): TableSchemaInterface|null
     {
-        throw new NotSupportedException(__METHOD__ . ' is not supported by this DBMS.');
+        return null;
     }
 }

--- a/tests/Support/Stub/Schema.php
+++ b/tests/Support/Stub/Schema.php
@@ -7,7 +7,6 @@ namespace Yiisoft\Db\Tests\Support\Stub;
 use Yiisoft\Db\Constraint\Constraint;
 use Yiisoft\Db\Exception\NotSupportedException;
 use Yiisoft\Db\Schema\AbstractSchema;
-use Yiisoft\Db\Schema\Column\ColumnFactoryInterface;
 use Yiisoft\Db\Schema\TableSchemaInterface;
 
 /**


### PR DESCRIPTION
- move `getColumnFactory()` from `SchemaInterface` to `ConnectionInterface`
- rename `QueryBuilderInterface::quoter()` to `QueryBuilderInterface::getQuoter()`
- remove `QueryBuilderInterface::getSchema()`
- add `QueryBuilderInterface::getColumnFactory()`
- change parameters in `AbstractQueryBuilder::__construct()`
- other minor refactoring

### Related PRs
- https://github.com/yiisoft/db-sqlite/pull/345
- https://github.com/yiisoft/db-mysql/pull/384
- https://github.com/yiisoft/db-pgsql/pull/393
- https://github.com/yiisoft/db-mssql/pull/350
- https://github.com/yiisoft/db-oracle/pull/313

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 