### PR TITLE
Added `->setWhere()` as force method `->where()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,6 @@
 - New #942: Allow PHP backed enums as values (@Tigrov)
 - Enh #943: Add `getCacheKey()` and `getCacheTag()` methods to `AbstractPdoSchema` class (@Tigrov)
 - Enh #944: Added `setWhere()` as method a forced for overwriting `where()` (@lav45)
-- Enh #925: Add callback to `Query::all()` and `Query::one()` methods (@Tigrov)
 - Enh #925, #951: Add callback to `Query::all()` and `Query::one()` methods (@Tigrov, @vjik)
 - New #954: Add `DbArrayHelper::arrange()` method (@Tigrov)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@
 - New #939: Add `caseSensitive` option to like condition (@vjik)
 - New #942: Allow PHP backed enums as values (@Tigrov)
 - Enh #943: Add `getCacheKey()` and `getCacheTag()` methods to `AbstractPdoSchema` class (@Tigrov)
+- Enh #944: Added `setWhere()` as method a forced for overwriting `where()` (@lav45)
 
 ## 1.3.0 March 21, 2024
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -120,6 +120,7 @@ Each table column has its own class in the `Yiisoft\Db\Schema\Column` namespace 
 - `QueryInterface::resultCallback()` - allows to use a callback, to be called on all rows of the query result;
 - `QueryInterface::getResultCallback()` - returns the callback to be called on all rows of the query result or 
   `null` if the callback is not set;
+- `QueryPartsInterface::setWhere()` - Overwrites the `WHERE` part of the query;
 - `ConnectionInterface::getColumnFactory()` - returns the column factory object for concrete DBMS;
 - `ConnectionInterface::getServerInfo()` - returns `ServerInfoInterface` instance which provides server information;
 - `QueryBuilderInterface::buildColumnDefinition()` - builds column definition for `CREATE TABLE` statement;

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -120,7 +120,7 @@ Each table column has its own class in the `Yiisoft\Db\Schema\Column` namespace 
 - `QueryInterface::resultCallback()` - allows to use a callback, to be called on all rows of the query result;
 - `QueryInterface::getResultCallback()` - returns the callback to be called on all rows of the query result or 
   `null` if the callback is not set;
-- `QueryPartsInterface::setWhere()` - Overwrites the `WHERE` part of the query;
+- `QueryPartsInterface::setWhere()` - overwrites the `WHERE` part of the query;
 - `ConnectionInterface::getColumnFactory()` - returns the column factory object for concrete DBMS;
 - `ConnectionInterface::getServerInfo()` - returns `ServerInfoInterface` instance which provides server information;
 - `QueryBuilderInterface::buildColumnDefinition()` - builds column definition for `CREATE TABLE` statement;

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -699,7 +699,7 @@ class Query implements QueryInterface
         if ($this->where === null) {
             $this->where = $condition;
         } else {
-            throw new LogicException('The `where` condition was set earlier. If you want to overwrite it, use the `setWhere()`, `andWhere()` or `orWhere()` method.');
+            throw new LogicException('The `where` condition was set earlier. Use the `setWhere()`, `andWhere()` or `orWhere()` method.');
         }
         $this->addParams($params);
         return $this;

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -717,7 +717,7 @@ class Query implements QueryInterface
         if ($this->where === null) {
             $this->where = $condition;
         } else {
-            throw new LogicException('The `where` condition was set earlier. If you want to overwrite it, use the `setWhere()` method.');
+            throw new LogicException('The `where` condition was set earlier. If you want to overwrite it, use the `setWhere()`, `andWhere()` or `orWhere()` method.');
         }
         $this->addParams($params);
         return $this;

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -668,9 +668,16 @@ class Query implements QueryInterface
         return $this;
     }
 
-    public function where(array|string|ExpressionInterface|null $condition, array $params = []): static
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function where(array|string|ExpressionInterface|null $condition, array $params = [], bool $force = false): static
     {
-        $this->where = $condition;
+        if ($this->where === null || $force === true) {
+            $this->where = $condition;
+        } else {
+            throw new InvalidArgumentException('The `where` condition was set earlier. If you want to overwrite it, then use the `force` parameter.');
+        }
         $this->addParams($params);
         return $this;
     }

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -671,13 +671,20 @@ class Query implements QueryInterface
     /**
      * @throws InvalidArgumentException
      */
-    public function where(array|string|ExpressionInterface|null $condition, array $params = [], bool $force = false): static
+    public function where(array|string|ExpressionInterface|null $condition, array $params = []): static
     {
-        if ($this->where === null || $force === true) {
+        if ($this->where === null) {
             $this->where = $condition;
         } else {
-            throw new InvalidArgumentException('The `where` condition was set earlier. If you want to overwrite it, then use the `force` parameter.');
+            throw new InvalidArgumentException('The `where` condition was set earlier. If you want to overwrite it, use the `setWhere()` method.');
         }
+        $this->addParams($params);
+        return $this;
+    }
+
+    public function setWhere(array|string|ExpressionInterface|null $condition, array $params = []): static
+    {
+        $this->where = $condition;
         $this->addParams($params);
         return $this;
     }

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -694,9 +694,6 @@ class Query implements QueryInterface
         return $this;
     }
 
-    /**
-     * @throws LogicException
-     */
     public function where(array|string|ExpressionInterface|null $condition, array $params = []): static
     {
         if ($this->where === null) {

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Db\Query;
 
 use Closure;
+use LogicException;
 use Throwable;
 use Yiisoft\Db\Command\CommandInterface;
 use Yiisoft\Db\Connection\ConnectionInterface;
@@ -669,14 +670,14 @@ class Query implements QueryInterface
     }
 
     /**
-     * @throws InvalidArgumentException
+     * @throws LogicException
      */
     public function where(array|string|ExpressionInterface|null $condition, array $params = []): static
     {
         if ($this->where === null) {
             $this->where = $condition;
         } else {
-            throw new InvalidArgumentException('The `where` condition was set earlier. If you want to overwrite it, use the `setWhere()` method.');
+            throw new LogicException('The `where` condition was set earlier. If you want to overwrite it, use the `setWhere()` method.');
         }
         $this->addParams($params);
         return $this;

--- a/src/Query/QueryPartsInterface.php
+++ b/src/Query/QueryPartsInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Db\Query;
 
 use Closure;
+use LogicException;
 use Yiisoft\Db\Connection\ConnectionInterface;
 use Yiisoft\Db\Exception\NotSupportedException;
 use Yiisoft\Db\Expression\ExpressionInterface;
@@ -670,6 +671,8 @@ interface QueryPartsInterface
      * @param array $params The parameters (name => value) to bind to the query.
      *
      * @psalm-param ParamsType $params
+     *
+     * @throws LogicException - if `where` was set previously
      *
      * @see andWhere()
      * @see orWhere()

--- a/src/Query/QueryPartsInterface.php
+++ b/src/Query/QueryPartsInterface.php
@@ -580,7 +580,7 @@ interface QueryPartsInterface
     public function union(QueryInterface|string $sql, bool $all = false): static;
 
     /**
-     * First sets the `WHERE` part of the query.
+     * Initially sets the `WHERE` part of the query.
      *
      * The `$condition` specified as an array can be in one of the following two formats:
      *

--- a/src/Query/QueryPartsInterface.php
+++ b/src/Query/QueryPartsInterface.php
@@ -668,13 +668,14 @@ interface QueryPartsInterface
      *
      * @param array|ExpressionInterface|string|null $condition The conditions to put in the `WHERE` part.
      * @param array $params The parameters (name => value) to bind to the query.
+     * @param bool $force Overwrite `where` conditions if it was set earlier
      *
      * @psalm-param ParamsType $params
      *
      * @see andWhere()
      * @see orWhere()
      */
-    public function where(array|string|ExpressionInterface|null $condition, array $params = []): static;
+    public function where(array|string|ExpressionInterface|null $condition, array $params = [], bool $force = false): static;
 
     /**
      * Prepends an SQL statement using `WITH` syntax.

--- a/src/Query/QueryPartsInterface.php
+++ b/src/Query/QueryPartsInterface.php
@@ -672,7 +672,7 @@ interface QueryPartsInterface
      *
      * @psalm-param ParamsType $params
      *
-     * @throws LogicException - if `where` was set previously
+     * @throws LogicException If `where` was set previously.
      *
      * @see andWhere()
      * @see orWhere()

--- a/src/Query/QueryPartsInterface.php
+++ b/src/Query/QueryPartsInterface.php
@@ -580,7 +580,7 @@ interface QueryPartsInterface
     public function union(QueryInterface|string $sql, bool $all = false): static;
 
     /**
-     * Sets the `WHERE` part of the query.
+     * First sets the `WHERE` part of the query.
      *
      * The `$condition` specified as an array can be in one of the following two formats:
      *
@@ -668,14 +668,25 @@ interface QueryPartsInterface
      *
      * @param array|ExpressionInterface|string|null $condition The conditions to put in the `WHERE` part.
      * @param array $params The parameters (name => value) to bind to the query.
-     * @param bool $force Overwrite `where` conditions if it was set earlier
      *
      * @psalm-param ParamsType $params
      *
      * @see andWhere()
      * @see orWhere()
      */
-    public function where(array|string|ExpressionInterface|null $condition, array $params = [], bool $force = false): static;
+    public function where(array|string|ExpressionInterface|null $condition, array $params = []): static;
+
+    /**
+     * Force sets the `WHERE` part of the query.
+     *
+     * @param array|ExpressionInterface|string|null $condition The conditions to put in the `WHERE` part.
+     * @param array $params The parameters (name => value) to bind to the query.
+     *
+     * @psalm-param ParamsType $params
+     *
+     * @see where()
+     */
+    public function setWhere(array|string|ExpressionInterface|null $condition, array $params = []): static;
 
     /**
      * Prepends an SQL statement using `WITH` syntax.

--- a/src/Query/QueryPartsInterface.php
+++ b/src/Query/QueryPartsInterface.php
@@ -677,7 +677,7 @@ interface QueryPartsInterface
     public function where(array|string|ExpressionInterface|null $condition, array $params = []): static;
 
     /**
-     * Force sets the `WHERE` part of the query.
+     * Overwrites the `WHERE` part of the query.
      *
      * @param array|ExpressionInterface|string|null $condition The conditions to put in the `WHERE` part.
      * @param array $params The parameters (name => value) to bind to the query.

--- a/tests/AbstractQueryBuilderTest.php
+++ b/tests/AbstractQueryBuilderTest.php
@@ -6,6 +6,7 @@ namespace Yiisoft\Db\Tests;
 
 use Closure;
 use JsonException;
+use LogicException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\TestCase;
@@ -475,7 +476,7 @@ abstract class AbstractQueryBuilderTest extends TestCase
     }
 
     /**
-     * @throws InvalidArgumentException
+     * @throws LogicException
      */
     public function testOverwriteWhereCondition(): void
     {
@@ -485,7 +486,7 @@ abstract class AbstractQueryBuilderTest extends TestCase
             (new Query($db))
                 ->where(['like', 'name', 'foo%'])
                 ->where(['not like', 'name', 'foo%']);
-        } catch (InvalidArgumentException $e) {
+        } catch (LogicException $e) {
             $this->assertEquals('The `where` condition was set earlier. If you want to overwrite it, use the `setWhere()` method.', $e->getMessage());
         }
 

--- a/tests/AbstractQueryBuilderTest.php
+++ b/tests/AbstractQueryBuilderTest.php
@@ -487,7 +487,7 @@ abstract class AbstractQueryBuilderTest extends TestCase
                 ->where(['like', 'name', 'foo%'])
                 ->where(['not like', 'name', 'foo%']);
         } catch (LogicException $e) {
-            $this->assertEquals('The `where` condition was set earlier. If you want to overwrite it, use the `setWhere()` method.', $e->getMessage());
+            $this->assertEquals('The `where` condition was set earlier. Use the `setWhere()`, `andWhere()` or `orWhere()` method.', $e->getMessage());
         }
 
         $query = (new Query($db))

--- a/tests/AbstractQueryBuilderTest.php
+++ b/tests/AbstractQueryBuilderTest.php
@@ -306,7 +306,7 @@ abstract class AbstractQueryBuilderTest extends TestCase
 
         $qb = $db->getQueryBuilder();
         $query = (new Query($db))->from('admin_user')->where(['is_deleted' => false]);
-        $query->where([])->andWhere(['in', 'id', ['1', '0']]);
+        $query->where([], force: true)->andWhere(['in', 'id', ['1', '0']]);
 
         [$sql, $params] = $qb->build($query);
 

--- a/tests/AbstractQueryBuilderTest.php
+++ b/tests/AbstractQueryBuilderTest.php
@@ -474,6 +474,25 @@ abstract class AbstractQueryBuilderTest extends TestCase
         }
     }
 
+    public function testOverwriteWhereCondition(): void
+    {
+        $db = $this->getConnection();
+
+        try {
+            (new Query($db))
+                ->where(['like', 'name', 'foo%'])
+                ->where(['not like', 'name', 'foo%']);
+        } catch (InvalidArgumentException $e) {
+            $this->assertEquals('The `where` condition was set earlier. If you want to overwrite it, then use the `force` parameter.', $e->getMessage());
+        }
+
+        $query = (new Query($db))
+            ->where(['like', 'name', 'foo%'])
+            ->where(['not like', 'name', 'foo%'], force: true);
+
+        $this->assertEquals(['not like', 'name', 'foo%'], $query->getWhere());
+    }
+
     public function testBuildLimit(): void
     {
         $db = $this->getConnection();

--- a/tests/AbstractQueryBuilderTest.php
+++ b/tests/AbstractQueryBuilderTest.php
@@ -306,7 +306,7 @@ abstract class AbstractQueryBuilderTest extends TestCase
 
         $qb = $db->getQueryBuilder();
         $query = (new Query($db))->from('admin_user')->where(['is_deleted' => false]);
-        $query->where([], force: true)->andWhere(['in', 'id', ['1', '0']]);
+        $query->setWhere([])->andWhere(['in', 'id', ['1', '0']]);
 
         [$sql, $params] = $qb->build($query);
 
@@ -474,6 +474,9 @@ abstract class AbstractQueryBuilderTest extends TestCase
         }
     }
 
+    /**
+     * @throws InvalidArgumentException
+     */
     public function testOverwriteWhereCondition(): void
     {
         $db = $this->getConnection();
@@ -483,12 +486,12 @@ abstract class AbstractQueryBuilderTest extends TestCase
                 ->where(['like', 'name', 'foo%'])
                 ->where(['not like', 'name', 'foo%']);
         } catch (InvalidArgumentException $e) {
-            $this->assertEquals('The `where` condition was set earlier. If you want to overwrite it, then use the `force` parameter.', $e->getMessage());
+            $this->assertEquals('The `where` condition was set earlier. If you want to overwrite it, use the `setWhere()` method.', $e->getMessage());
         }
 
         $query = (new Query($db))
             ->where(['like', 'name', 'foo%'])
-            ->where(['not like', 'name', 'foo%'], force: true);
+            ->setWhere(['not like', 'name', 'foo%']);
 
         $this->assertEquals(['not like', 'name', 'foo%'], $query->getWhere());
     }


### PR DESCRIPTION
Added `->where(force: true)` to protect against accidental overwriting `where` condition

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | 


```php
$query = (new Query($db))
    ->where(['like', 'name', 'foo%'])
    ->where(['not like', 'name', 'foo%']); // => throw new LogicException()
```

This solves the problem of accidentally overriding the `where` condition.
If you really want to redefine `where`, then you should use the `setWhere()` or `andWhere()` or `orWhere()` method.

```php
$query = (new Query($db))
    ->where(['like', 'name', 'foo%'])
    ->setWhere(['not like', 'name', 'foo%']);

$this->assertEquals(['not like', 'name', 'foo%'], $query->getWhere());
```