### PR TITLE
Remove nullable from `PdoConnectionInterface::getActivePdo()` result + Minor refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@
 - Enh #943: Add `getCacheKey()` and `getCacheTag()` methods to `AbstractPdoSchema` class (@Tigrov)
 - Enh #925, #951: Add callback to `Query::all()` and `Query::one()` methods (@Tigrov, @vjik)
 - New #954: Add `DbArrayHelper::arrange()` method (@Tigrov)
+- Chg #956: Remove nullable from `PdoConnectionInterface::getActivePdo()` result (@vjik)
 
 ## 1.3.0 March 21, 2024
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -189,3 +189,4 @@ Each table column has its own class in the `Yiisoft\Db\Schema\Column` namespace 
 - Change return type of `AbstractCommand::insertWithReturningPks()` method to `array|false`;
 - Rename `QueryBuilderInterface::quoter()` method to `QueryBuilderInterface::getQuoter()`;
 - Change constructor parameters in `AbstractQueryBuilder` class;
+- Remove nullable from `PdoConnectionInterface::getActivePdo()` result;

--- a/src/Driver/Pdo/AbstractPdoCommand.php
+++ b/src/Driver/Pdo/AbstractPdoCommand.php
@@ -141,10 +141,10 @@ abstract class AbstractPdoCommand extends AbstractCommand implements PdoCommandI
             return;
         }
 
-        $pdo = $this->db->getActivePDO($sql, $forRead);
+        $pdo = $this->db->getActivePdo($sql, $forRead);
 
         try {
-            $this->pdoStatement = $pdo?->prepare($sql);
+            $this->pdoStatement = $pdo->prepare($sql);
             $this->bindPendingParams();
         } catch (PDOException $e) {
             $message = $e->getMessage() . "\nFailed to prepare SQL: $sql";

--- a/src/Driver/Pdo/AbstractPdoConnection.php
+++ b/src/Driver/Pdo/AbstractPdoConnection.php
@@ -139,10 +139,10 @@ abstract class AbstractPdoConnection extends AbstractConnection implements PdoCo
         return $this->emulatePrepare;
     }
 
-    public function getActivePDO(string|null $sql = '', bool|null $forRead = null): PDO
+    public function getActivePdo(string|null $sql = '', bool|null $forRead = null): PDO
     {
         $this->open();
-        $pdo = $this->getPDO();
+        $pdo = $this->getPdo();
 
         if ($pdo === null) {
             throw new Exception('PDO cannot be initialized.');
@@ -151,7 +151,7 @@ abstract class AbstractPdoConnection extends AbstractConnection implements PdoCo
         return $pdo;
     }
 
-    public function getPDO(): PDO|null
+    public function getPdo(): PDO|null
     {
         return $this->pdo;
     }
@@ -186,7 +186,7 @@ abstract class AbstractPdoConnection extends AbstractConnection implements PdoCo
             return $value;
         }
 
-        return $this->getActivePDO()->quote($value);
+        return $this->getActivePdo()->quote($value);
     }
 
     public function setEmulatePrepare(bool $value): void

--- a/src/Driver/Pdo/AbstractPdoTransaction.php
+++ b/src/Driver/Pdo/AbstractPdoTransaction.php
@@ -64,7 +64,7 @@ abstract class AbstractPdoTransaction implements TransactionInterface, LoggerAwa
                 ['type' => LogType::TRANSACTION]
             );
 
-            $this->db->getPDO()?->beginTransaction();
+            $this->db->getPdo()?->beginTransaction();
             $this->level = 1;
 
             return;
@@ -105,7 +105,7 @@ abstract class AbstractPdoTransaction implements TransactionInterface, LoggerAwa
                 'Commit transaction ' . __METHOD__,
                 ['type' => LogType::TRANSACTION]
             );
-            $this->db->getPDO()?->commit();
+            $this->db->getPdo()?->commit();
 
             return;
         }
@@ -134,7 +134,7 @@ abstract class AbstractPdoTransaction implements TransactionInterface, LoggerAwa
     public function isActive(): bool
     {
         /** Extra check pdo->inTransaction {@link https://github.com/yiisoft/yii2/pull/18407/} */
-        return $this->level > 0 && $this->db->isActive() && $this->db->getPDO()?->inTransaction();
+        return $this->level > 0 && $this->db->isActive() && $this->db->getPdo()?->inTransaction();
     }
 
     public function rollBack(): void
@@ -155,7 +155,7 @@ abstract class AbstractPdoTransaction implements TransactionInterface, LoggerAwa
                 'Roll back transaction ' . __METHOD__,
                 ['type' => LogType::TRANSACTION]
             );
-            $this->db->getPDO()?->rollBack();
+            $this->db->getPdo()?->rollBack();
 
             return;
         }

--- a/src/Driver/Pdo/PdoConnectionInterface.php
+++ b/src/Driver/Pdo/PdoConnectionInterface.php
@@ -23,9 +23,9 @@ interface PdoConnectionInterface extends ConnectionInterface
      * @throws Exception
      * @throws InvalidConfigException
      *
-     * @return PDO|null The {@see PDO} instance for the current connection.
+     * @return PDO The {@see PDO} instance for the current connection.
      */
-    public function getActivePDO(string $sql = '', ?bool $forRead = null): PDO|null;
+    public function getActivePdo(string $sql = '', ?bool $forRead = null): PDO;
 
     /**
      * The PHP {@see PDO} instance associated with this DB connection.
@@ -39,7 +39,7 @@ interface PdoConnectionInterface extends ConnectionInterface
      *
      * @see PDO
      */
-    public function getPDO(): PDO|null;
+    public function getPdo(): PDO|null;
 
     /**
      * Returns current DB driver.

--- a/src/Driver/Pdo/PdoServerInfo.php
+++ b/src/Driver/Pdo/PdoServerInfo.php
@@ -19,7 +19,7 @@ class PdoServerInfo implements ServerInfoInterface
     {
         if ($this->version === null) {
             /** @var string */
-            $this->version = $this->db->getActivePDO()?->getAttribute(PDO::ATTR_SERVER_VERSION) ?? '';
+            $this->version = $this->db->getActivePdo()->getAttribute(PDO::ATTR_SERVER_VERSION) ?? '';
         }
 
         return $this->version;

--- a/tests/AbstractConnectionTest.php
+++ b/tests/AbstractConnectionTest.php
@@ -144,13 +144,13 @@ abstract class AbstractConnectionTest extends TestCase
         $connection = $this->getConnection();
         $connection->open();
         $serialized = serialize($connection);
-        $this->assertNotNull($connection->getPDO());
+        $this->assertNotNull($connection->getPdo());
 
         $unserialized = unserialize($serialized);
         $this->assertInstanceOf(PdoConnectionInterface::class, $unserialized);
-        $this->assertNull($unserialized->getPDO());
+        $this->assertNull($unserialized->getPdo());
         $this->assertEquals(123, $unserialized->createCommand('SELECT 123')->queryScalar());
-        $this->assertNotNull($connection->getPDO());
+        $this->assertNotNull($connection->getPdo());
     }
 
     private function getProfiler(): ProfilerInterface

--- a/tests/AbstractPdoConnectionTest.php
+++ b/tests/AbstractPdoConnectionTest.php
@@ -26,7 +26,7 @@ abstract class AbstractPdoConnectionTest extends TestCase
 
         $this->assertNotSame($db, $db2);
         $this->assertNull($db2->getTransaction());
-        $this->assertNull($db2->getPDO());
+        $this->assertNull($db2->getPdo());
     }
 
     public function testGetDriver(): void
@@ -52,17 +52,17 @@ abstract class AbstractPdoConnectionTest extends TestCase
         $db = $this->getConnection();
 
         $this->assertFalse($db->isActive());
-        $this->assertNull($db->getPDO());
+        $this->assertNull($db->getPdo());
 
         $db->open();
 
         $this->assertTrue($db->isActive());
-        $this->assertInstanceOf(PDO::class, $db->getPDO());
+        $this->assertInstanceOf(PDO::class, $db->getPdo());
 
         $db->close();
 
         $this->assertFalse($db->isActive());
-        $this->assertNull($db->getPDO());
+        $this->assertNull($db->getPdo());
 
         $this->setDsn('unknown::memory:');
 
@@ -83,12 +83,12 @@ abstract class AbstractPdoConnectionTest extends TestCase
         $db = $this->getConnection();
 
         $this->assertFalse($db->isActive());
-        $this->assertNull($db->getPDO());
+        $this->assertNull($db->getPdo());
 
         $db->open();
 
         $this->assertTrue($db->isActive());
-        $this->assertInstanceOf(PDO::class, $db->getPDO());
+        $this->assertInstanceOf(PDO::class, $db->getPdo());
 
         $logger = $this->getLogger();
         $logger->expects(self::once())->method('log');
@@ -97,7 +97,7 @@ abstract class AbstractPdoConnectionTest extends TestCase
         $db->close();
 
         $this->assertFalse($db->isActive());
-        $this->assertNull($db->getPDO());
+        $this->assertNull($db->getPdo());
 
         $this->setDsn('unknown::memory:');
 

--- a/tests/Common/CommonCommandTest.php
+++ b/tests/Common/CommonCommandTest.php
@@ -2027,7 +2027,7 @@ abstract class CommonCommandTest extends AbstractCommandTest
     public function testPrepareWithEmptySql()
     {
         $db = $this->createMock(PdoConnectionInterface::class);
-        $db->expects(self::never())->method('getActivePDO');
+        $db->expects(self::never())->method('getActivePdo');
 
         $command = new class ($db) extends AbstractPdoCommand {
             public function showDatabases(): array

--- a/tests/Common/CommonPdoCommandTest.php
+++ b/tests/Common/CommonPdoCommandTest.php
@@ -164,7 +164,7 @@ abstract class CommonPdoCommandTest extends TestCase
     {
         $db = $this->getConnection(true);
 
-        $this->assertSame(PDO::CASE_NATURAL, $db->getActivePDO()?->getAttribute(PDO::ATTR_CASE));
+        $this->assertSame(PDO::CASE_NATURAL, $db->getActivePdo()?->getAttribute(PDO::ATTR_CASE));
 
         $command = $db->createCommand();
         $sql = <<<SQL
@@ -176,9 +176,9 @@ abstract class CommonPdoCommandTest extends TestCase
         $this->assertTrue(isset($rows[0]['customer_id']));
         $this->assertTrue(isset($rows[0]['total']));
 
-        $db->getActivePDO()?->setAttribute(PDO::ATTR_CASE, PDO::CASE_LOWER);
+        $db->getActivePdo()?->setAttribute(PDO::ATTR_CASE, PDO::CASE_LOWER);
 
-        $this->assertSame(PDO::CASE_LOWER, $db->getActivePDO()?->getAttribute(PDO::ATTR_CASE));
+        $this->assertSame(PDO::CASE_LOWER, $db->getActivePdo()?->getAttribute(PDO::ATTR_CASE));
 
         $rows = $command->setSql($sql)->queryAll();
 
@@ -186,9 +186,9 @@ abstract class CommonPdoCommandTest extends TestCase
         $this->assertTrue(isset($rows[0]['customer_id']));
         $this->assertTrue(isset($rows[0]['total']));
 
-        $db->getActivePDO()?->setAttribute(PDO::ATTR_CASE, PDO::CASE_UPPER);
+        $db->getActivePdo()?->setAttribute(PDO::ATTR_CASE, PDO::CASE_UPPER);
 
-        $this->assertSame(PDO::CASE_UPPER, $db->getActivePDO()?->getAttribute(PDO::ATTR_CASE));
+        $this->assertSame(PDO::CASE_UPPER, $db->getActivePdo()?->getAttribute(PDO::ATTR_CASE));
 
         $rows = $command->setSql($sql)->queryAll();
 

--- a/tests/Common/CommonPdoCommandTest.php
+++ b/tests/Common/CommonPdoCommandTest.php
@@ -164,7 +164,7 @@ abstract class CommonPdoCommandTest extends TestCase
     {
         $db = $this->getConnection(true);
 
-        $this->assertSame(PDO::CASE_NATURAL, $db->getActivePdo()?->getAttribute(PDO::ATTR_CASE));
+        $this->assertSame(PDO::CASE_NATURAL, $db->getActivePdo()->getAttribute(PDO::ATTR_CASE));
 
         $command = $db->createCommand();
         $sql = <<<SQL
@@ -176,9 +176,9 @@ abstract class CommonPdoCommandTest extends TestCase
         $this->assertTrue(isset($rows[0]['customer_id']));
         $this->assertTrue(isset($rows[0]['total']));
 
-        $db->getActivePdo()?->setAttribute(PDO::ATTR_CASE, PDO::CASE_LOWER);
+        $db->getActivePdo()->setAttribute(PDO::ATTR_CASE, PDO::CASE_LOWER);
 
-        $this->assertSame(PDO::CASE_LOWER, $db->getActivePdo()?->getAttribute(PDO::ATTR_CASE));
+        $this->assertSame(PDO::CASE_LOWER, $db->getActivePdo()->getAttribute(PDO::ATTR_CASE));
 
         $rows = $command->setSql($sql)->queryAll();
 
@@ -186,9 +186,9 @@ abstract class CommonPdoCommandTest extends TestCase
         $this->assertTrue(isset($rows[0]['customer_id']));
         $this->assertTrue(isset($rows[0]['total']));
 
-        $db->getActivePdo()?->setAttribute(PDO::ATTR_CASE, PDO::CASE_UPPER);
+        $db->getActivePdo()->setAttribute(PDO::ATTR_CASE, PDO::CASE_UPPER);
 
-        $this->assertSame(PDO::CASE_UPPER, $db->getActivePdo()?->getAttribute(PDO::ATTR_CASE));
+        $this->assertSame(PDO::CASE_UPPER, $db->getActivePdo()->getAttribute(PDO::ATTR_CASE));
 
         $rows = $command->setSql($sql)->queryAll();
 

--- a/tests/Common/CommonPdoConnectionTest.php
+++ b/tests/Common/CommonPdoConnectionTest.php
@@ -363,7 +363,7 @@ abstract class CommonPdoConnectionTest extends AbstractPdoConnectionTest
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('PDO cannot be initialized.');
 
-        $db->getActivePDO();
+        $db->getActivePdo();
     }
 
     private function getProfiler(): ProfilerInterface

--- a/tests/Common/CommonSchemaTest.php
+++ b/tests/Common/CommonSchemaTest.php
@@ -388,7 +388,7 @@ abstract class CommonSchemaTest extends AbstractSchemaTest
                 continue;
             }
 
-            $db->getPDO()?->setAttribute($name, $value);
+            $db->getPdo()?->setAttribute($name, $value);
         }
 
         $schema = $db->getSchema();
@@ -460,7 +460,7 @@ abstract class CommonSchemaTest extends AbstractSchemaTest
                 continue;
             }
 
-            $db->getPDO()?->setAttribute($name, $value);
+            $db->getPdo()?->setAttribute($name, $value);
         }
 
         $schema = $db->getSchema();
@@ -485,11 +485,11 @@ abstract class CommonSchemaTest extends AbstractSchemaTest
         $db = $this->getConnection(true);
 
         $schema = $db->getSchema();
-        $db->getActivePDO()->setAttribute(PDO::ATTR_CASE, PDO::CASE_LOWER);
+        $db->getActivePdo()->setAttribute(PDO::ATTR_CASE, PDO::CASE_LOWER);
 
         $this->assertCount(count($schema->getTableNames()), $schema->getTableSchemas());
 
-        $db->getActivePDO()->setAttribute(PDO::ATTR_CASE, PDO::CASE_UPPER);
+        $db->getActivePdo()->setAttribute(PDO::ATTR_CASE, PDO::CASE_UPPER);
 
         $this->assertCount(count($schema->getTableNames()), $schema->getTableSchemas());
 
@@ -744,7 +744,7 @@ abstract class CommonSchemaTest extends AbstractSchemaTest
         $db = $this->getConnection(true);
 
         $schema = $db->getSchema();
-        $db->getActivePDO()->setAttribute(PDO::ATTR_CASE, PDO::CASE_LOWER);
+        $db->getActivePdo()->setAttribute(PDO::ATTR_CASE, PDO::CASE_LOWER);
         $constraints = $schema->{'getTable' . ucfirst($type)}($tableName, true);
 
         $this->assertMetadataEquals($expected, $constraints);
@@ -768,7 +768,7 @@ abstract class CommonSchemaTest extends AbstractSchemaTest
         $db = $this->getConnection(true);
 
         $schema = $db->getSchema();
-        $db->getActivePDO()->setAttribute(PDO::ATTR_CASE, PDO::CASE_UPPER);
+        $db->getActivePdo()->setAttribute(PDO::ATTR_CASE, PDO::CASE_UPPER);
         $constraints = $schema->{'getTable' . ucfirst($type)}($tableName, true);
 
         $this->assertMetadataEquals($expected, $constraints);

--- a/tests/Support/DbHelper.php
+++ b/tests/Support/DbHelper.php
@@ -74,7 +74,7 @@ final class DbHelper
 
         foreach ($lines as $line) {
             if (trim($line) !== '') {
-                $db->getPDO()?->exec($line);
+                $db->getPdo()?->exec($line);
             }
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
Fix #908 

+ Rename `getActivePDO()` to `getActivePdo()` and `getPDO()` to `getPdo()`.