### PR TITLE
Make `Query::andHaving()` like `Query::andWhere()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@
 - Enh #941: Add the ability for user-defined type casting (@Tigrov)
 - Enh #961: Added `setHaving()` as a forced method to overwrite `having()` (@lav45)
 - Enh #822: Refactor data readers (@Tigrov)
+- Enh #963: Make `Query::andHaving()` similar to `Query::andWhere()` (@Tigrov)
 
 ## 1.3.0 March 21, 2024
 

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -185,6 +185,12 @@ class Query implements QueryInterface
     {
         if ($this->having === null) {
             $this->having = $condition;
+        } elseif (
+            is_array($this->having)
+            && isset($this->having[0])
+            && strcasecmp((string) $this->having[0], 'and') === 0
+        ) {
+            $this->having[] = $condition;
         } else {
             $this->having = ['and', $this->having, $condition];
         }
@@ -221,7 +227,11 @@ class Query implements QueryInterface
     {
         if ($this->where === null) {
             $this->where = $condition;
-        } elseif (is_array($this->where) && isset($this->where[0]) && strcasecmp((string) $this->where[0], 'and') === 0) {
+        } elseif (
+            is_array($this->where)
+            && isset($this->where[0])
+            && strcasecmp((string) $this->where[0], 'and') === 0
+        ) {
             $this->where[] = $condition;
         } else {
             $this->where = ['and', $this->where, $condition];

--- a/tests/AbstractQueryTest.php
+++ b/tests/AbstractQueryTest.php
@@ -421,9 +421,19 @@ abstract class AbstractQueryTest extends TestCase
         $this->assertSame(['and', 'id = :id', 'name = :name'], $query->getHaving());
         $this->assertSame([':id' => 1, ':name' => 'something'], $query->getParams());
 
+        $query->andHaving('is_active = :is_active', [':is_active' => true]);
+        $this->assertSame(['and', 'id = :id', 'name = :name', 'is_active = :is_active'], $query->getHaving());
+        $this->assertSame([':id' => 1, ':name' => 'something', ':is_active' => true], $query->getParams());
+
         $query->orHaving('age = :age', [':age' => '30']);
-        $this->assertSame(['or', ['and', 'id = :id', 'name = :name'], 'age = :age'], $query->getHaving());
-        $this->assertSame([':id' => 1, ':name' => 'something', ':age' => '30'], $query->getParams());
+        $this->assertSame(
+            ['or', ['and', 'id = :id', 'name = :name', 'is_active = :is_active'], 'age = :age'],
+            $query->getHaving(),
+        );
+        $this->assertSame(
+            [':id' => 1, ':name' => 'something', ':is_active' => true, ':age' => '30'],
+            $query->getParams(),
+        );
     }
 
     public function testJoin(): void
@@ -724,14 +734,22 @@ abstract class AbstractQueryTest extends TestCase
         $this->assertSame([':id' => 1], $query->getParams());
 
         $query->andWhere('name = :name', [':name' => 'something']);
-
         $this->assertSame(['and', 'id = :id', 'name = :name'], $query->getWhere());
         $this->assertSame([':id' => 1, ':name' => 'something'], $query->getParams());
 
-        $query->orWhere('age = :age', [':age' => '30']);
+        $query->andWhere('is_active = :is_active', [':is_active' => true]);
+        $this->assertSame(['and', 'id = :id', 'name = :name', 'is_active = :is_active'], $query->getWhere());
+        $this->assertSame([':id' => 1, ':name' => 'something', ':is_active' => true], $query->getParams());
 
-        $this->assertSame(['or', ['and', 'id = :id', 'name = :name'], 'age = :age'], $query->getWhere());
-        $this->assertSame([':id' => 1, ':name' => 'something', ':age' => '30'], $query->getParams());
+        $query->orWhere('age = :age', [':age' => '30']);
+        $this->assertSame(
+            ['or', ['and', 'id = :id', 'name = :name', 'is_active = :is_active'], 'age = :age'],
+            $query->getWhere(),
+        );
+        $this->assertSame(
+            [':id' => 1, ':name' => 'something', ':is_active' => true, ':age' => '30'],
+            $query->getParams(),
+        );
     }
 
     public function testWithQueries(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #77
