### PR TITLE
Rename `getLastInsertID()` method in `ConnectionInterface` to `getLastInsertId()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@
 - Enh #822: Refactor data readers (@Tigrov)
 - Enh #963: Make `Query::andHaving()` similar to `Query::andWhere()` (@Tigrov)
 - New #964: Add `QueryBuilderInterface::replacePlaceholders()` method (@Tigrov)
+- Enh #879: Rename `getLastInsertID()` method in `ConnectionInterface` to `getLastInsertId()` (@vjik)
 
 ## 1.3.0 March 21, 2024
 

--- a/src/Connection/ConnectionInterface.php
+++ b/src/Connection/ConnectionInterface.php
@@ -109,7 +109,7 @@ interface ConnectionInterface
      *
      * @return string The row ID of the last row inserted, or the last value retrieved from the sequence object.
      */
-    public function getLastInsertID(?string $sequenceName = null): string;
+    public function getLastInsertId(?string $sequenceName = null): string;
 
     /**
      * Returns the query builder for the current DB connection.

--- a/src/Debug/ConnectionInterfaceProxy.php
+++ b/src/Debug/ConnectionInterfaceProxy.php
@@ -69,9 +69,9 @@ final class ConnectionInterfaceProxy implements ConnectionInterface
         return $this->connection->getColumnFactory();
     }
 
-    public function getLastInsertID(?string $sequenceName = null): string
+    public function getLastInsertId(?string $sequenceName = null): string
     {
-        return $this->connection->getLastInsertID($sequenceName);
+        return $this->connection->getLastInsertId($sequenceName);
     }
 
     public function getQueryBuilder(): QueryBuilderInterface

--- a/src/Driver/Pdo/AbstractPdoConnection.php
+++ b/src/Driver/Pdo/AbstractPdoConnection.php
@@ -160,7 +160,7 @@ abstract class AbstractPdoConnection extends AbstractConnection implements PdoCo
         return $this->pdo;
     }
 
-    public function getLastInsertID(?string $sequenceName = null): string
+    public function getLastInsertId(?string $sequenceName = null): string
     {
         if ($this->pdo !== null) {
             return $this->pdo->lastInsertID($sequenceName ?? null);

--- a/tests/Common/CommonCommandTest.php
+++ b/tests/Common/CommonCommandTest.php
@@ -1333,9 +1333,9 @@ abstract class CommonCommandTest extends AbstractCommandTest
         $command->insert('{{order}}', ['customer_id' => 1, 'created_at' => $time, 'total' => 42])->execute();
 
         if ($db->getDriverName() === 'pgsql') {
-            $orderId = $db->getLastInsertID('public.order_id_seq');
+            $orderId = $db->getLastInsertId('public.order_id_seq');
         } else {
-            $orderId = $db->getLastInsertID();
+            $orderId = $db->getLastInsertId();
         }
 
         $columnValueQuery = (new Query($db))->select('{{created_at}}')->from('{{order}}')->where(['id' => $orderId]);
@@ -1630,9 +1630,9 @@ abstract class CommonCommandTest extends AbstractCommandTest
         )->execute();
 
         if ($db->getDriverName() === 'pgsql') {
-            $customerId = $db->getLastInsertID('public.customer_id_seq');
+            $customerId = $db->getLastInsertId('public.customer_id_seq');
         } else {
-            $customerId = $db->getLastInsertID();
+            $customerId = $db->getLastInsertId();
         }
 
         $customer = $command->setSql(

--- a/tests/Common/CommonPdoConnectionTest.php
+++ b/tests/Common/CommonPdoConnectionTest.php
@@ -312,7 +312,7 @@ abstract class CommonPdoConnectionTest extends AbstractPdoConnectionTest
             'createCommand',
             'close',
             'getDriverName',
-            'getLastInsertID',
+            'getLastInsertId',
             'getQueryBuilder',
             'getQuoter',
             'getSchema',

--- a/tests/Db/Driver/PDO/PdoConnectionTest.php
+++ b/tests/Db/Driver/PDO/PdoConnectionTest.php
@@ -36,7 +36,7 @@ final class PdoConnectionTest extends AbstractPdoConnectionTest
         $this->expectException(InvalidCallException::class);
         $this->expectExceptionMessage('DB Connection is not active.');
 
-        $db->getLastInsertID();
+        $db->getLastInsertId();
     }
 
     public function testQuoteValueString(): void

--- a/tests/Support/Stub/Schema.php
+++ b/tests/Support/Stub/Schema.php
@@ -22,14 +22,6 @@ class Schema extends AbstractSchema
         throw new NotSupportedException(__METHOD__ . ' is not supported by this DBMS.');
     }
 
-    /**
-     * @throws NotSupportedException
-     */
-    public function getLastInsertID(?string $sequenceName = null): string
-    {
-        throw new NotSupportedException(__METHOD__ . ' is not supported by this DBMS.');
-    }
-
     protected function getCacheKey(string $name): array
     {
         return [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
Fix #879 

Related PRs:
- https://github.com/yiisoft/db-mysql/pull/392
- https://github.com/yiisoft/db-oracle/pull/322
- https://github.com/yiisoft/db-pgsql/pull/406
- https://github.com/yiisoft/db-sqlite/pull/353