### PR TITLE
Fix memory leaking in `Command::exists()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@
 - Chg #972: Change in query "distinct" flag type from `bool|null` to `bool` (@vjik)
 - New #973: Add `upsertWithReturningPks()` method to `CommandInterface` and `DMLQueryBuilderInterface` (@Tigrov)
 - New #968: Add `DateTimeColumn` column class (@Tigrov)
+- Bug #978: Fix memory leaking in `Command::exists()` method (@Tigrov)
 
 ## 1.3.0 March 21, 2024
 

--- a/src/QueryBuilder/AbstractDQLQueryBuilder.php
+++ b/src/QueryBuilder/AbstractDQLQueryBuilder.php
@@ -468,7 +468,7 @@ abstract class AbstractDQLQueryBuilder implements DQLQueryBuilderInterface
 
     public function selectExists(string $rawSql): string
     {
-        return 'SELECT EXISTS(' . $rawSql . ')';
+        return 'SELECT EXISTS(' . $rawSql . ') AS ' . $this->quoter->quoteSimpleColumnName('0');
     }
 
     public function setConditionClasses(array $classes): void

--- a/tests/AbstractQueryBuilderTest.php
+++ b/tests/AbstractQueryBuilderTest.php
@@ -2129,17 +2129,17 @@ abstract class AbstractQueryBuilderTest extends TestCase
         $qb->resetSequence('noExist', 1);
     }
 
-    /**
-     * @dataProvider \Yiisoft\Db\Tests\Provider\QueryBuilderProvider::selectExist
-     */
-    public function testSelectExists(string $sql, string $expected): void
+    public function testSelectExists(): void
     {
         $db = $this->getConnection();
-
         $qb = $db->getQueryBuilder();
-        $sqlSelectExist = $qb->selectExists($sql);
 
-        $this->assertSame($expected, $sqlSelectExist);
+        $sql = DbHelper::replaceQuotes('SELECT 1 FROM [[table]] WHERE [[id]] = 1', $db->getDriverName());
+        // Alias required to avoid memory leaking on MySQL. Other DBMS have the same alias for consistency.
+        // @link https://github.com/yiisoft/yii2/issues/20385
+        $expected = DbHelper::replaceQuotes('SELECT EXISTS(SELECT 1 FROM [[table]] WHERE [[id]] = 1) AS [[0]]', $db->getDriverName());
+
+        $this->assertSame($expected, $qb->selectExists($sql));
     }
 
     /**

--- a/tests/AbstractQueryBuilderTest.php
+++ b/tests/AbstractQueryBuilderTest.php
@@ -2134,10 +2134,13 @@ abstract class AbstractQueryBuilderTest extends TestCase
         $db = $this->getConnection();
         $qb = $db->getQueryBuilder();
 
-        $sql = DbHelper::replaceQuotes('SELECT 1 FROM [[table]] WHERE [[id]] = 1', $db->getDriverName());
+        $sql = DbHelper::replaceQuotes('SELECT 1 FROM [[customer]] WHERE [[id]] = 1', $db->getDriverName());
         // Alias required to avoid memory leaking on MySQL. Other DBMS have the same alias for consistency.
         // @link https://github.com/yiisoft/yii2/issues/20385
-        $expected = DbHelper::replaceQuotes('SELECT EXISTS(SELECT 1 FROM [[table]] WHERE [[id]] = 1) AS [[0]]', $db->getDriverName());
+        $expected = DbHelper::replaceQuotes(
+            'SELECT EXISTS(SELECT 1 FROM [[customer]] WHERE [[id]] = 1) AS [[0]]',
+            $db->getDriverName()
+        );
 
         $this->assertSame($expected, $qb->selectExists($sql));
     }

--- a/tests/Provider/QueryBuilderProvider.php
+++ b/tests/Provider/QueryBuilderProvider.php
@@ -1141,26 +1141,6 @@ class QueryBuilderProvider
         ];
     }
 
-    public static function selectExist(): array
-    {
-        return [
-            [
-                DbHelper::replaceQuotes(
-                    <<<SQL
-                    SELECT 1 FROM `table` WHERE `id` = 1
-                    SQL,
-                    static::$driverName,
-                ),
-                DbHelper::replaceQuotes(
-                    <<<SQL
-                    SELECT EXISTS(SELECT 1 FROM `table` WHERE `id` = 1)
-                    SQL,
-                    static::$driverName,
-                ),
-            ],
-        ];
-    }
-
     public static function selectScalar(): array
     {
         return [


### PR DESCRIPTION
### Related PRs
- https://github.com/yiisoft/db-mssql/pull/363
- https://github.com/yiisoft/db-oracle/pull/326

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | https://github.com/yiisoft/yii2/issues/20385