### PR TITLE
Remove `requireTransaction()` and `$isolationLevel` from `AbstractCommand`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@
 - New #988: Add `CaseExpression` and `CaseExpressionBuilder` to build `CASE-WHEN-THEN-ELSE` SQL expressions (@Tigrov)
 - Enh #991: Improve types in `ConnectionInterface::transaction()` (@kikara)
 - Chg #998: Add `yiisoft/db-implementation` virtual package as dependency (@vjik)
+- Chg #999: Remove `requireTransaction()` method and `$isolationLevel` property from `AbstractCommand` (@vjik)
 
 ## 1.3.0 March 21, 2024
 

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -114,11 +114,6 @@ abstract class AbstractCommand implements CommandInterface
     protected const QUERY_MODE_SCALAR = 32;
 
     /**
-     * @var string|null Transaction isolation level.
-     */
-    protected string|null $isolationLevel = null;
-
-    /**
      * @var ParamInterface[] Parameters to use.
      */
     protected array $params = [];
@@ -664,19 +659,6 @@ abstract class AbstractCommand implements CommandInterface
     }
 
     /**
-     * Marks the command to execute in transaction.
-     *
-     * @param string|null $isolationLevel The isolation level to use for this transaction.
-     *
-     * {@see \Yiisoft\Db\Transaction\TransactionInterface::begin()} for details.
-     */
-    protected function requireTransaction(?string $isolationLevel = null): static
-    {
-        $this->isolationLevel = $isolationLevel;
-        return $this;
-    }
-
-    /**
      * Resets the command object, so it can be reused to build another SQL statement.
      */
     protected function reset(): void
@@ -684,7 +666,6 @@ abstract class AbstractCommand implements CommandInterface
         $this->sql = '';
         $this->params = [];
         $this->refreshTableName = null;
-        $this->isolationLevel = null;
         $this->retryHandler = null;
     }
 

--- a/src/Driver/Pdo/AbstractPdoCommand.php
+++ b/src/Driver/Pdo/AbstractPdoCommand.php
@@ -206,10 +206,7 @@ abstract class AbstractPdoCommand extends AbstractCommand implements PdoCommandI
      */
     protected function internalExecute(): void
     {
-        $attempt = 0;
-
-        while (true) {
-            $attempt++;
+        for ($attempt = 0; ; ++$attempt) {
             try {
                 set_error_handler(
                     static fn(int $errorNumber, string $errorString): bool =>

--- a/src/Driver/Pdo/AbstractPdoCommand.php
+++ b/src/Driver/Pdo/AbstractPdoCommand.php
@@ -209,28 +209,18 @@ abstract class AbstractPdoCommand extends AbstractCommand implements PdoCommandI
         $attempt = 0;
 
         while (true) {
+            $attempt++;
             try {
-                if (
-                    ++$attempt === 1
-                    && $this->isolationLevel !== null
-                    && $this->db->getTransaction() === null
-                ) {
-                    $this->db->transaction(
-                        fn () => $this->internalExecute(),
-                        $this->isolationLevel
-                    );
-                } else {
-                    set_error_handler(
-                        static fn(int $errorNumber, string $errorString): bool =>
-                            str_starts_with($errorString, 'Packets out of order. Expected '),
-                        E_WARNING,
-                    );
+                set_error_handler(
+                    static fn(int $errorNumber, string $errorString): bool =>
+                        str_starts_with($errorString, 'Packets out of order. Expected '),
+                    E_WARNING,
+                );
 
-                    try {
-                        $this->pdoStatement?->execute();
-                    } finally {
-                        restore_error_handler();
-                    }
+                try {
+                    $this->pdoStatement?->execute();
+                } finally {
+                    restore_error_handler();
                 }
                 break;
             } catch (PDOException $e) {

--- a/tests/Common/CommonCommandTest.php
+++ b/tests/Common/CommonCommandTest.php
@@ -1128,68 +1128,6 @@ abstract class CommonCommandTest extends AbstractCommandTest
         $db->close();
     }
 
-    /**
-     * @throws Exception
-     * @throws InvalidConfigException
-     * @throws ReflectionException
-     * @throws Throwable
-     */
-    public function testExecuteWithTransaction(): void
-    {
-        $db = $this->getConnection(true);
-
-        $this->assertNull($db->getTransaction());
-
-        $command = $db->createCommand(
-            <<<SQL
-            INSERT INTO {{profile}} ([[description]]) VALUES('command transaction 1')
-            SQL,
-        );
-
-        Assert::invokeMethod($command, 'requireTransaction');
-
-        $command->execute();
-
-        $this->assertNull($db->getTransaction());
-
-        $this->assertEquals(
-            1,
-            $db->createCommand(
-                <<<SQL
-                SELECT COUNT(*) FROM {{profile}} WHERE [[description]] = 'command transaction 1'
-                SQL,
-            )->queryScalar(),
-        );
-
-        $command = $db->createCommand(
-            <<<SQL
-            INSERT INTO {{profile}} ([[description]]) VALUES('command transaction 2')
-            SQL,
-        );
-
-        Assert::invokeMethod($command, 'requireTransaction', [TransactionInterface::READ_UNCOMMITTED]);
-
-        $command->execute();
-
-        $this->assertNull($db->getTransaction());
-
-        $this->assertEquals(
-            1,
-            $db->createCommand(
-                <<<SQL
-                SELECT COUNT(*) FROM {{profile}} WHERE [[description]] = 'command transaction 2'
-                SQL,
-            )->queryScalar(),
-        );
-
-        $db->close();
-    }
-
-    /**
-     * @throws Exception
-     * @throws InvalidConfigException
-     * @throws Throwable
-     */
     public function testInsert(): void
     {
         $db = $this->getConnection(true);
@@ -1878,12 +1816,6 @@ abstract class CommonCommandTest extends AbstractCommandTest
         $db->close();
     }
 
-    /**
-     * @throws Exception
-     * @throws InvalidConfigException
-     * @throws ReflectionException
-     * @throws Throwable
-     */
     public function testSetRetryHandler(): void
     {
         $db = $this->getConnection(true);
@@ -1942,47 +1874,6 @@ abstract class CommonCommandTest extends AbstractCommandTest
         $db->close();
     }
 
-    /**
-     * @throws Exception
-     * @throws InvalidConfigException
-     * @throws ReflectionException
-     * @throws Throwable
-     */
-    public function testTransaction(): void
-    {
-        $db = $this->getConnection(true);
-
-        $this->assertNull($db->getTransaction());
-
-        $command = $db->createCommand();
-        $command = $command->setSql(
-            <<<SQL
-            INSERT INTO [[profile]] ([[description]]) VALUES('command transaction')
-            SQL
-        );
-
-        Assert::invokeMethod($command, 'requireTransaction');
-
-        $command->execute();
-
-        $this->assertNull($db->getTransaction());
-        $this->assertEquals(
-            1,
-            $command->setSql(
-                <<<SQL
-                SELECT COUNT(*) FROM [[profile]] WHERE [[description]] = 'command transaction'
-                SQL
-            )->queryScalar(),
-        );
-
-        $db->close();
-    }
-
-    /**
-     * @throws Exception
-     * @throws InvalidConfigException
-     * @throws Throwable
-     */
     public function testTruncateTable(): void
     {
         $db = $this->getConnection(true);

--- a/tests/Common/CommonCommandTest.php
+++ b/tests/Common/CommonCommandTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Yiisoft\Db\Tests\Common;
 
 use PHPUnit\Framework\Attributes\DataProviderExternal;
-use ReflectionException;
 use Throwable;
 use Yiisoft\Db\Constant\DataType;
 use Yiisoft\Db\Command\Param;
@@ -31,7 +30,6 @@ use Yiisoft\Db\Tests\AbstractCommandTest;
 use Yiisoft\Db\Tests\Provider\CommandProvider;
 use Yiisoft\Db\Tests\Support\Assert;
 use Yiisoft\Db\Tests\Support\DbHelper;
-use Yiisoft\Db\Transaction\TransactionInterface;
 
 use function array_filter;
 use function is_string;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
Fix #782 

Related PRs:

- https://github.com/yiisoft/db-oracle/pull/337