### PR TITLE
Improve `Quoter::getTableNameParts()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@
 - Chg #1001: Add public properties `$type` and `$value` to `Param` class instead of `getType()` and `getValue()` methods that were removed (@vjik)
 - Chg #1002: Remove specific condition interfaces (@vjik)
 - Chg #1003, #1006: Refactor namespace of condition objects and use promoted properties instead of getters (@vjik)
+- Enh #1010: Improve `Quoter::getTableNameParts()` method (@Tigrov)
 
 ## 1.3.0 March 21, 2024
 

--- a/src/Schema/Quoter.php
+++ b/src/Schema/Quoter.php
@@ -96,11 +96,21 @@ class Quoter implements QuoterInterface
         return $name;
     }
 
+    /** @psalm-return array{schemaName?: string, name: string} */
     public function getTableNameParts(string $name): array
     {
-        $parts = array_slice(explode('.', $name), -2, 2);
+        $parts = array_reverse(array_slice(explode('.', $name), -2, 2));
+        /** @var string[] */
+        $parts = array_map($this->unquoteSimpleTableName(...), $parts);
 
-        return array_map($this->unquoteSimpleTableName(...), $parts);
+        if (!isset($parts[1])) {
+            return ['name' => $parts[0]];
+        }
+
+        return [
+            'schemaName' => $parts[1],
+            'name' => $parts[0],
+        ];
     }
 
     public function ensureNameQuoted(string $name): string

--- a/src/Schema/QuoterInterface.php
+++ b/src/Schema/QuoterInterface.php
@@ -39,7 +39,9 @@ interface QuoterInterface
     public function getRawTableName(string $name): string;
 
     /**
-     * Splits full table name into parts.
+     * Splits a full table name into parts in the appropriate order, using the part name as the key.
+     *
+     * For example, "dbname.tblname" will be split into an array `['schemaName' => 'dbname', 'name' => 'tblname']`
      *
      * @param string $name The full name of the table.
      *

--- a/tests/AbstractQuoterTest.php
+++ b/tests/AbstractQuoterTest.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace Yiisoft\Db\Tests;
 
+use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\TestCase;
+use Yiisoft\Db\Tests\Provider\QuoterProvider;
 use Yiisoft\Db\Tests\Support\TestTrait;
 
 abstract class AbstractQuoterTest extends TestCase
 {
     use TestTrait;
 
-    /**
-     * @dataProvider \Yiisoft\Db\Tests\Provider\QuoterProvider::ensureColumnName
-     */
+    #[DataProviderExternal(QuoterProvider::class, 'ensureColumnName')]
     public function testEnsureColumnName(string $columnName, string $expected): void
     {
         $db = $this->getConnection();
@@ -21,9 +21,7 @@ abstract class AbstractQuoterTest extends TestCase
         $this->assertSame($expected, $db->getQuoter()->ensureColumnName($columnName));
     }
 
-    /**
-     * @dataProvider \Yiisoft\Db\Tests\Provider\QuoterProvider::ensureNameQuoted
-     */
+    #[DataProviderExternal(QuoterProvider::class, 'ensureNameQuoted')]
     public function testEnsureNameQuoted(string $name, string $expected): void
     {
         $db = $this->getConnection();
@@ -31,9 +29,7 @@ abstract class AbstractQuoterTest extends TestCase
         $this->assertSame($expected, $db->getQuoter()->ensureNameQuoted($name));
     }
 
-    /**
-     * @dataProvider \Yiisoft\Db\Tests\Provider\QuoterProvider::rawTableNames
-     */
+    #[DataProviderExternal(QuoterProvider::class, 'rawTableNames')]
     public function testGetRawTableName(string $tableName, string $expected, string $tablePrefix = ''): void
     {
         $db = $this->getConnection();
@@ -43,19 +39,15 @@ abstract class AbstractQuoterTest extends TestCase
         $this->assertSame($expected, $db->getQuoter()->getRawTableName($tableName));
     }
 
-    /**
-     * @dataProvider \Yiisoft\Db\Tests\Provider\QuoterProvider::tableNameParts
-     */
-    public function testGetTableNameParts(string $tableName, string ...$expected): void
+    #[DataProviderExternal(QuoterProvider::class, 'tableNameParts')]
+    public function testGetTableNameParts(string $tableName, array $expected): void
     {
         $db = $this->getConnection();
 
-        $this->assertSame($expected, array_reverse($db->getQuoter()->getTableNameParts($tableName)));
+        $this->assertSame($expected, $db->getQuoter()->getTableNameParts($tableName));
     }
 
-    /**
-     * @dataProvider \Yiisoft\Db\Tests\Provider\QuoterProvider::columnNames
-     */
+    #[DataProviderExternal(QuoterProvider::class, 'columnNames')]
     public function testQuoteColumnName(string $columnName, string $expected): void
     {
         $db = $this->getConnection();
@@ -63,9 +55,7 @@ abstract class AbstractQuoterTest extends TestCase
         $this->assertSame($expected, $db->getQuoter()->quoteColumnName($columnName));
     }
 
-    /**
-     * @dataProvider \Yiisoft\Db\Tests\Provider\QuoterProvider::simpleColumnNames
-     */
+    #[DataProviderExternal(QuoterProvider::class, 'simpleColumnNames')]
     public function testQuoteSimpleColumnName(
         string $columnName,
         string $expectedQuotedColumnName,
@@ -83,9 +73,7 @@ abstract class AbstractQuoterTest extends TestCase
         $this->assertSame($expectedUnQuotedColumnName, $unQuoted);
     }
 
-    /**
-     * @dataProvider \Yiisoft\Db\Tests\Provider\QuoterProvider::simpleTableNames
-     */
+    #[DataProviderExternal(QuoterProvider::class, 'simpleTableNames')]
     public function testQuoteTableName(string $tableName, string $expected): void
     {
         $db = $this->getConnection();

--- a/tests/Db/Schema/QuoterTest.php
+++ b/tests/Db/Schema/QuoterTest.php
@@ -82,7 +82,7 @@ final class QuoterTest extends AbstractQuoterTest
     {
         $quoter = new Quoter('`', '"');
 
-        $this->assertSame(['schema', 'table'], $quoter->getTableNameParts('"schema"."table"'));
+        $this->assertSame(['schemaName' => 'schema', 'name' => 'table'], $quoter->getTableNameParts('"schema"."table"'));
     }
 
     public function testQuoteSqlWithTablePrefix(): void

--- a/tests/Provider/QuoterProvider.php
+++ b/tests/Provider/QuoterProvider.php
@@ -91,18 +91,17 @@ class QuoterProvider
         ];
     }
 
-    /**
-     * @return string[][]
-     */
     public static function tableNameParts(): array
     {
         return [
-            ['animal', 'animal',],
-            ['dbo.animal', 'animal', 'dbo'],
-            ['[dbo].[animal]', 'animal', 'dbo'],
-            ['[other].[animal2]', 'animal2', 'other'],
-            ['other.[animal2]', 'animal2', 'other'],
-            ['other.animal2', 'animal2', 'other'],
+            ['', ['name' => '']],
+            ['[]', ['name' => '']],
+            ['animal', ['name' => 'animal']],
+            ['[animal]', ['name' => 'animal']],
+            ['dbo.animal', ['schemaName' => 'dbo', 'name' => 'animal']],
+            ['[dbo].[animal]', ['schemaName' => 'dbo', 'name' => 'animal']],
+            ['[dbo].animal', ['schemaName' => 'dbo', 'name' => 'animal']],
+            ['dbo.[animal]', ['schemaName' => 'dbo', 'name' => 'animal']],
         ];
     }
 


### PR DESCRIPTION
### Related PRs
- https://github.com/yiisoft/db-sqlite/pull/376
- https://github.com/yiisoft/db-mysql/pull/413
- https://github.com/yiisoft/db-pgsql/pull/430
- https://github.com/yiisoft/db-mssql/pull/382
- https://github.com/yiisoft/db-oracle/pull/347

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
| Fixed issues  | 