### PR TITLE
Replace "escaping replacements" methods with "escape" constructor parameter in `Like`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,8 @@
 - Enh #1010: Improve `Quoter::getTableNameParts()` method (@Tigrov)
 - Enh #1011: Refactor `TableSchemaInterface` and `AbstractSchema` (@Tigrov)
 - Enh #1011: Remove `AbstractTableSchema` and add `TableSchema` instead (@Tigrov)
+- Chg #1014: Replace `getEscapingReplacements()`/`setEscapingReplacements()` methods with `escape` constructor parameter 
+  in `Like` condition (@vjik)
 
 ## 1.3.0 March 21, 2024
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -195,6 +195,8 @@ Each table column has its own class in the `Yiisoft\Db\Schema\Column` namespace 
 - `AbstractDQLQueryBuilder::hasOffset()` - use `!empty($offset)` instead;
 - `BatchQueryResultInterface::reset()` - use `BatchQueryResultInterface::rewind()` instead;
 - `BatchQueryResult::reset()` - use `BatchQueryResult::rewind()` instead;
+- `Like::getEscapingReplacements()`/`LikeCondition::setEscapingReplacements()` - use `escape` constructor parameter
+  instead;
 
 ### Remove deprecated parameters
 

--- a/docs/guide/en/query/where.md
+++ b/docs/guide/en/query/where.md
@@ -181,15 +181,14 @@ When the value range is given as an array, many `LIKE` predicates will be genera
 
 For example, `['like', 'name', ['test', 'sample']]` will generate `name LIKE '%test%' AND name LIKE '%sample%'`.
 
-You may also give an optional third operand to specify how to escape special characters in the values.
-The operand should be an array of mappings from the special characters to their escaped counterparts.
+You may also provide an optional `escape` parameter to control whether special characters in the values should be 
+escaped. If `escape` is `true` (default), special characters like `%`, `_`, and `\` will be escaped and the values will
+be automatically wrapped with `%`. If `escape` is `false`, the values will be used as-is without any escaping or 
+wrapping.
 
-If this operand isn't provided, a default escape mapping will be used.
-
-You may use false or an empty array to indicate the values are already escaped and no escape should be applied.
-
-> Note: That when using an escape mapping (or the third operand isn't provided),
-> the values will be automatically inside within a pair of percentage characters.
+For example:
+- `['like', 'name', 'test']` will generate `name LIKE '%test%'` (default escaping)
+- `['like', 'name', 'test%', 'escape' => false]` will generate `name LIKE 'test%'` (no escaping or wrapping)
 
 Optionally, you can specify the case sensitivity of the `LIKE` condition by passing boolean value with `caseSensitive` 
 key, e.g. `['like', 'name', 'Ivan', 'caseSensitive' => true]`.

--- a/tests/Db/QueryBuilder/Condition/LikeTest.php
+++ b/tests/Db/QueryBuilder/Condition/LikeTest.php
@@ -22,6 +22,7 @@ final class LikeTest extends TestCase
         $this->assertSame('LIKE', $likeCondition->operator);
         $this->assertSame('test', $likeCondition->value);
         $this->assertNull($likeCondition->caseSensitive);
+        $this->assertTrue($likeCondition->escape);
     }
 
     public function testFromArrayDefinition(): void
@@ -32,6 +33,7 @@ final class LikeTest extends TestCase
         $this->assertSame('LIKE', $likeCondition->operator);
         $this->assertSame('test', $likeCondition->value);
         $this->assertNull($likeCondition->caseSensitive);
+        $this->assertTrue($likeCondition->escape);
     }
 
     public function testFromArrayDefinitionException(): void
@@ -60,22 +62,14 @@ final class LikeTest extends TestCase
         Like::fromArrayDefinition('LIKE', ['id', false]);
     }
 
-    public function testFromArrayDefinitionSetEscapingReplacements(): void
+    public function testFromArrayDefinitionWithEscape(): void
     {
-        $likeCondition = Like::fromArrayDefinition('LIKE', ['id', 'test', ['%' => '\%', '_' => '\_']]);
+        $likeCondition = Like::fromArrayDefinition('LIKE', ['id', 'test', 'escape' => false]);
 
         $this->assertSame('id', $likeCondition->column);
         $this->assertSame('LIKE', $likeCondition->operator);
         $this->assertSame('test', $likeCondition->value);
-        $this->assertSame(['%' => '\%', '_' => '\_'], $likeCondition->getEscapingReplacements());
-    }
-
-    public function testSetEscapingReplacements(): void
-    {
-        $likeCondition = new Like('id', 'LIKE', 'test');
-        $likeCondition->setEscapingReplacements(['%' => '\%', '_' => '\_']);
-
-        $this->assertSame(['%' => '\%', '_' => '\_'], $likeCondition->getEscapingReplacements());
+        $this->assertFalse($likeCondition->escape);
     }
 
     #[TestWith([null])]

--- a/tests/Provider/QueryBuilderProvider.php
+++ b/tests/Provider/QueryBuilderProvider.php
@@ -828,7 +828,7 @@ class QueryBuilderProvider
             /**
              * {@see https://github.com/yiisoft/yii2/issues/15630}
              */
-            [['like', 'location.title_ru', 'vi%', null], '[[location]].[[title_ru]] LIKE :qp0', [':qp0' => new Param('vi%', DataType::STRING)]],
+            [['like', 'location.title_ru', 'vi%', 'escape' => false], '[[location]].[[title_ru]] LIKE :qp0', [':qp0' => new Param('vi%', DataType::STRING)]],
 
             /* like object conditions */
             [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌

Relative PRs:
- https://github.com/yiisoft/db-oracle/pull/350