### PR TITLE
Refactor `AbstractDMLQueryBuilder::getTableUniqueColumnNames()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@
 - New #1013: Add `StringableStream` class to cast binary column values to `string` using `(string) $value` (@Tigrov)
 - Chg #1014: Replace `getEscapingReplacements()`/`setEscapingReplacements()` methods with `escape` constructor parameter 
   in `Like` condition (@vjik)
+- Enh #1016: Refactor `AbstractDMLQueryBuilder::getTableUniqueColumnNames()` method (@Tigrov)
 
 ## 1.3.0 March 21, 2024
 

--- a/src/QueryBuilder/AbstractDMLQueryBuilder.php
+++ b/src/QueryBuilder/AbstractDMLQueryBuilder.php
@@ -36,12 +36,8 @@ use function in_array;
 use function is_array;
 use function is_string;
 use function iterator_to_array;
-use function json_encode;
 use function preg_match;
 use function reset;
-use function sort;
-
-use const JSON_THROW_ON_ERROR;
 
 /**
  * It's used to manipulate data in tables.

--- a/src/QueryBuilder/AbstractDMLQueryBuilder.php
+++ b/src/QueryBuilder/AbstractDMLQueryBuilder.php
@@ -483,7 +483,6 @@ abstract class AbstractDMLQueryBuilder implements DMLQueryBuilderInterface
             return [];
         }
 
-        /** @var string[][] $columnNames */
         return array_unique(array_merge(...$columnNames));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 
