### PR TITLE
 Change result type of `getExpressionBuilder()` methods to `ExpressionBuilderInterface`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,8 @@
 - New #1033: Add `All` and `None` conditions (@vjik)
 - New #1034: Add `ConnectionInterface::getColumnBuilderClass()` method (@Tigrov)
 - Enh #1031: Optimize SQL generation for `Not` condition (@vjik)
+- Chg #1037: Change result type of `QueryBuilderInterface::getExpressionBuilder()` and
+  `DQLQueryBuilderInterface::getExpressionBuilder()` methods to `ExpressionBuilderInterface` (@vjik)
 
 ## 1.3.0 March 21, 2024
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -270,3 +270,6 @@ Each table column has its own class in the `Yiisoft\Db\Schema\Column` namespace 
 - Remove `AbstractTableSchema` and add `TableSchema` instead;
 - Remove `BetweenColumns` condition;
 - Move expression builders to `Yiisoft\Db\Expression\Builder` namespace;
+- Change `QueryBuilderInterface::getExpressionBuilder()` result type to `ExpressionBuilderInterface`;
+- Change `DQLQueryBuilderInterface::getExpressionBuilder()` result type to `ExpressionBuilderInterface`;
+

--- a/src/QueryBuilder/AbstractDQLQueryBuilder.php
+++ b/src/QueryBuilder/AbstractDQLQueryBuilder.php
@@ -182,9 +182,9 @@ abstract class AbstractDQLQueryBuilder implements DQLQueryBuilderInterface
 
     public function buildExpression(ExpressionInterface $expression, array &$params = []): string
     {
-        $builder = $this->queryBuilder->getExpressionBuilder($expression);
-        /** @psalm-suppress MixedMethodCall */
-        return (string) $builder->build($expression, $params);
+        return $this->queryBuilder
+            ->getExpressionBuilder($expression)
+            ->build($expression, $params);
     }
 
     public function buildFor(array $values): string
@@ -468,7 +468,7 @@ abstract class AbstractDQLQueryBuilder implements DQLQueryBuilderInterface
         return count($conditions) === 1 ? $conditions[0] : new Condition\AndX(...$conditions);
     }
 
-    public function getExpressionBuilder(ExpressionInterface $expression): object
+    public function getExpressionBuilder(ExpressionInterface $expression): ExpressionBuilderInterface
     {
         $className = $expression::class;
 

--- a/src/QueryBuilder/AbstractQueryBuilder.php
+++ b/src/QueryBuilder/AbstractQueryBuilder.php
@@ -10,6 +10,7 @@ use JsonSerializable;
 use Stringable;
 use Traversable;
 use Yiisoft\Db\Command\CommandInterface;
+use Yiisoft\Db\Expression\Builder\ExpressionBuilderInterface;
 use Yiisoft\Db\Expression\Param;
 use Yiisoft\Db\Constant\DataType;
 use Yiisoft\Db\Connection\ConnectionInterface;
@@ -409,7 +410,7 @@ abstract class AbstractQueryBuilder implements QueryBuilderInterface
         return $this->db->getColumnFactory();
     }
 
-    public function getExpressionBuilder(ExpressionInterface $expression): object
+    public function getExpressionBuilder(ExpressionInterface $expression): ExpressionBuilderInterface
     {
         return $this->dqlBuilder->getExpressionBuilder($expression);
     }

--- a/src/QueryBuilder/DQLQueryBuilderInterface.php
+++ b/src/QueryBuilder/DQLQueryBuilderInterface.php
@@ -313,9 +313,9 @@ interface DQLQueryBuilderInterface
     /**
      * @throws InvalidArgumentException
      *
-     * @return object Instance of {@see ExpressionBuilderInterface} for the given expression.
+     * @return ExpressionBuilderInterface Instance of {@see ExpressionBuilderInterface} for the given expression.
      */
-    public function getExpressionBuilder(ExpressionInterface $expression): object;
+    public function getExpressionBuilder(ExpressionInterface $expression): ExpressionBuilderInterface;
 
     /**
      * Creates a `SELECT EXISTS()` SQL statement.

--- a/src/QueryBuilder/QueryBuilderInterface.php
+++ b/src/QueryBuilder/QueryBuilderInterface.php
@@ -87,7 +87,7 @@ interface QueryBuilderInterface extends DDLQueryBuilderInterface, DMLQueryBuilde
      *
      * @throws InvalidArgumentException When expression building isn't supported by this QueryBuilder.
      */
-    public function getExpressionBuilder(ExpressionInterface $expression): object;
+    public function getExpressionBuilder(ExpressionInterface $expression): ExpressionBuilderInterface;
 
     /**
      * Returns {@see ServerInfoInterface} instance that provides information about the database server.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️

