### PR TITLE
Add `ordered` option to `ArrayMerge`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,7 +136,7 @@
 - Enh #1031: Optimize SQL generation for `Not` condition (@vjik)
 - Chg #1037: Change result type of `QueryBuilderInterface::getExpressionBuilder()` and
   `DQLQueryBuilderInterface::getExpressionBuilder()` methods to `ExpressionBuilderInterface` (@vjik)
-- New #1029: Add functions as expressions (@Tigrov)
+- New #1029, #1048: Add functions as expressions (@Tigrov)
 - Enh #1042: Refactor `AbstractDMLQueryBuilder` class to `upsert()` method (@Tigrov)
 - New #1040, #1043: Add `DateTimeValue` class (@vjik, @Tigrov)
 

--- a/src/Expression/Function/ArrayMerge.php
+++ b/src/Expression/Function/ArrayMerge.php
@@ -23,7 +23,16 @@ use Yiisoft\Db\Schema\Column\ColumnInterface;
  */
 final class ArrayMerge extends MultiOperandFunction
 {
+    private bool $ordered = false;
     private string|ColumnInterface $type = '';
+
+    /**
+     * Returns whether the result array should be ordered.
+     */
+    public function getOrdered(): bool
+    {
+        return $this->ordered;
+    }
 
     /**
      * Returns the type of the operands. Empty string if not set.
@@ -31,6 +40,15 @@ final class ArrayMerge extends MultiOperandFunction
     public function getType(): string|ColumnInterface
     {
         return $this->type;
+    }
+
+    /**
+     * Sets whether the result array should be ordered.
+     */
+    public function ordered(bool $ordered = true): self
+    {
+        $this->ordered = $ordered;
+        return $this;
     }
 
     /**

--- a/tests/Db/Expression/Function/ArrayMergeTest.php
+++ b/tests/Db/Expression/Function/ArrayMergeTest.php
@@ -25,4 +25,15 @@ final class ArrayMergeTest extends TestCase
         $this->assertSame($expression, $expression->type($intColumn));
         $this->assertSame($intColumn, $expression->getType());
     }
+
+    public function testOrdered(): void
+    {
+        $expression = new ArrayMerge();
+
+        $this->assertFalse($expression->getOrdered());
+        $this->assertSame($expression, $expression->ordered());
+        $this->assertTrue($expression->getOrdered());
+        $this->assertSame($expression, $expression->ordered(false));
+        $this->assertFalse($expression->getOrdered());
+    }
 }


### PR DESCRIPTION
### Related PRs
- https://github.com/yiisoft/db-sqlite/pull/390
- https://github.com/yiisoft/db-mysql/pull/427
- https://github.com/yiisoft/db-pgsql/pull/446
- https://github.com/yiisoft/db-mssql/pull/396
- https://github.com/yiisoft/db-oracle/pull/363

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 
