### PR TITLE
Remove @internal from abstract conditions

### DIFF
--- a/src/QueryBuilder/Condition/AbstractBetween.php
+++ b/src/QueryBuilder/Condition/AbstractBetween.php
@@ -10,8 +10,6 @@ use Yiisoft\Db\Expression\ExpressionInterface;
 use function is_string;
 
 /**
- * @internal
- *
  * Condition that's represented `BETWEEN` or `NOT BETWEEN` operator is used to check if a value is between two values.
  */
 abstract class AbstractBetween implements ConditionInterface

--- a/src/QueryBuilder/Condition/AbstractCompare.php
+++ b/src/QueryBuilder/Condition/AbstractCompare.php
@@ -11,8 +11,6 @@ use function array_key_exists;
 use function is_string;
 
 /**
- * @internal
- *
  * Abstract condition that represents comparison operators.
  */
 abstract class AbstractCompare implements ConditionInterface

--- a/src/QueryBuilder/Condition/AbstractExists.php
+++ b/src/QueryBuilder/Condition/AbstractExists.php
@@ -10,8 +10,6 @@ use Yiisoft\Db\Query\QueryInterface;
 use function sprintf;
 
 /**
- * @internal
- *
  * Represents `EXISTS` and `NOT EXISTS` operators.
  */
 abstract class AbstractExists implements ConditionInterface

--- a/src/QueryBuilder/Condition/AbstractIn.php
+++ b/src/QueryBuilder/Condition/AbstractIn.php
@@ -13,8 +13,6 @@ use function is_array;
 use function is_string;
 
 /**
- * @internal
- *
  * Represents `IN` and `NOT IN` operators.
  */
 abstract class AbstractIn implements ConditionInterface

--- a/src/QueryBuilder/Condition/AbstractLike.php
+++ b/src/QueryBuilder/Condition/AbstractLike.php
@@ -12,8 +12,6 @@ use function is_string;
 use function sprintf;
 
 /**
- * @internal
- *
  * Condition that represents `LIKE` operator.
  */
 abstract class AbstractLike implements ConditionInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌

Psalm thinks in final classes these methods are internal:

`ERROR: InternalMethod - src/Blog/Infrastructure/DbPostRepository.php:43:30 - Constructor Yiisoft\Db\QueryBuilder\Condition\AbstractCompare::__construct is internal to Yiisoft but called from App\Blog\Infrastructure\DbPostRepository::hasBySlug (see https://psalm.dev/175)
            $query->andWhere(new NotEquals('id', $excludeId));`

