### PR TITLE
`Stringable` value support in `Like` and `NotLike` conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,7 @@
 - New #1057: Add `CompositeExpression` class (@vjik)
 - Chg #1058: Refactor `Expression` class: declare `$expression` and `$params` as public readonly properties, remove 
   `getParams()` method (@vjik)
+- New #1062: `Stringable` value support in `Like` and `NotLike` conditions (@vjik)
 
 ## 1.3.0 March 21, 2024
 

--- a/src/QueryBuilder/Condition/AbstractLike.php
+++ b/src/QueryBuilder/Condition/AbstractLike.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Db\QueryBuilder\Condition;
 
 use InvalidArgumentException;
+use Stringable;
 use Yiisoft\Db\Expression\ExpressionInterface;
 
 use function is_int;
@@ -22,7 +23,7 @@ abstract class AbstractLike implements ConditionInterface
 
     /**
      * @param ExpressionInterface|string $column The column name.
-     * @param ExpressionInterface|int|iterable|string|null $value The value to the right of operator.
+     * @param ExpressionInterface|int|iterable|string|Stringable|null $value The value to the right of operator.
      * @param bool|null $caseSensitive Whether the comparison is case-sensitive. `null` means using the default
      * behavior.
      * @param bool $escape Whether to escape the value. Defaults to `true`. If `false`, the value will be used as is
@@ -32,7 +33,7 @@ abstract class AbstractLike implements ConditionInterface
      */
     final public function __construct(
         public readonly string|ExpressionInterface $column,
-        public readonly iterable|int|string|ExpressionInterface|null $value,
+        public readonly iterable|int|string|Stringable|ExpressionInterface|null $value,
         public readonly ?bool $caseSensitive = null,
         public readonly bool $escape = self::DEFAULT_ESCAPE,
         public readonly LikeMode $mode = self::DEFAULT_MODE,

--- a/src/QueryBuilder/Condition/Builder/LikeBuilder.php
+++ b/src/QueryBuilder/Condition/Builder/LikeBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Db\QueryBuilder\Condition\Builder;
 
+use Stringable;
 use Traversable;
 use Yiisoft\Db\Expression\Value\Param;
 use Yiisoft\Db\Constant\DataType;
@@ -86,7 +87,7 @@ class LikeBuilder implements ExpressionBuilderInterface
 
         $parts = [];
         foreach ($values as $value) {
-            /** @var ExpressionInterface|int|string $value */
+            /** @var ExpressionInterface|int|string|Stringable $value */
             $placeholderName = $this->preparePlaceholderName($value, $expression, $params);
             $parts[] = "$column $operator $placeholderName" . static::ESCAPE_SQL;
         }
@@ -132,12 +133,16 @@ class LikeBuilder implements ExpressionBuilderInterface
      * @return string
      */
     protected function preparePlaceholderName(
-        string|int|ExpressionInterface $value,
+        string|Stringable|int|ExpressionInterface $value,
         Like|NotLike $condition,
         array &$params,
     ): string {
         if ($value instanceof ExpressionInterface) {
             return $this->queryBuilder->buildExpression($value, $params);
+        }
+
+        if ($value instanceof Stringable) {
+            $value = (string) $value;
         }
 
         if (is_string($value) && $condition->escape) {

--- a/tests/Db/QueryBuilder/Condition/Builder/LikeBuilderTest.php
+++ b/tests/Db/QueryBuilder/Condition/Builder/LikeBuilderTest.php
@@ -11,6 +11,7 @@ use Yiisoft\Db\Constant\DataType;
 use Yiisoft\Db\QueryBuilder\Condition\Builder\LikeBuilder;
 use Yiisoft\Db\QueryBuilder\Condition\Like;
 use Yiisoft\Db\QueryBuilder\Condition\LikeMode;
+use Yiisoft\Db\Tests\Support\Stringable;
 use Yiisoft\Db\Tests\Support\TestTrait;
 
 /**
@@ -31,6 +32,25 @@ final class LikeBuilderTest extends TestCase
 
         $params = [];
         $likeBuilder->build($likeCondition, $params);
+
+        $this->assertCount(1, $params);
+
+        /** @var Param $param */
+        $param = reset($params);
+        $this->assertSame($expected, $param->value);
+        $this->assertSame(DataType::STRING, $param->type);
+    }
+
+    #[TestWith(['%test%', 'test', true])]
+    #[TestWith(['%te\_st%', 'te_st', true])]
+    #[TestWith(['%te_st%', 'te_st', false])]
+    public function testStringableValue(string $expected, string $value, bool $escape): void
+    {
+        $condition = new Like('column', new Stringable($value), escape: $escape);
+        $builder = new LikeBuilder($this->getConnection()->getQueryBuilder());
+
+        $params = [];
+        $builder->build($condition, $params);
 
         $this->assertCount(1, $params);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌

Related PRs:

- https://github.com/yiisoft/db-oracle/pull/368

