### PR TITLE
Remove parameters from `PdoConnectionInterface::getActivePdo()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,7 @@
 - Bug #1099: Fix an issue where `AbstractSchema::refresh()` didn't completely clear cache (@vjik) 
 - Bug #1103: Fix view names' cache refreshing after "drop table" command execution (@vjik)
 - Chg #1103: Remove `AbstractCommand::refreshTableSchema()` method (@vjik)
+- Chg #1106: Remove parameters from `PdoConnectionInterface::getActivePdo()` method (@vjik)
 
 ## 1.3.0 March 21, 2024
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -234,7 +234,7 @@ Each table column has its own class in the `Yiisoft\Db\Schema\Column` namespace 
 - Change return type of `AbstractCommand::insertWithReturningPks()` method to `array|false`;
 - Rename `QueryBuilderInterface::quoter()` method to `QueryBuilderInterface::getQuoter()`;
 - Change constructor parameters in `AbstractQueryBuilder` class;
-- Remove nullable from `PdoConnectionInterface::getActivePdo()` result;
+- Remove parameters and nullable result from `PdoConnectionInterface::getActivePdo()`;
 - Move `Yiisoft\Db\Query\Data\DataReaderInterface` interface to `Yiisoft\Db\Query` namespace;
 - Move `Yiisoft\Db\Query\Data\DataReader` class to `Yiisoft\Db\Driver\Pdo` namespace and rename it to `PdoDataReader`;
 - Add `indexBy()` and `resultCallback()` methods to `DataReaderInterface` and `PdoDataReader` class;

--- a/src/Driver/Pdo/AbstractPdoCommand.php
+++ b/src/Driver/Pdo/AbstractPdoCommand.php
@@ -149,7 +149,7 @@ abstract class AbstractPdoCommand extends AbstractCommand implements PdoCommandI
             return;
         }
 
-        $pdo = $this->db->getActivePdo($sql, $forRead);
+        $pdo = $this->db->getActivePdo();
 
         try {
             $this->pdoStatement = $pdo->prepare($sql);

--- a/src/Driver/Pdo/AbstractPdoConnection.php
+++ b/src/Driver/Pdo/AbstractPdoConnection.php
@@ -142,7 +142,7 @@ abstract class AbstractPdoConnection extends AbstractConnection implements PdoCo
         return $this->emulatePrepare;
     }
 
-    public function getActivePdo(?string $sql = '', ?bool $forRead = null): PDO
+    public function getActivePdo(): PDO
     {
         $this->open();
         $pdo = $this->getPdo();

--- a/src/Driver/Pdo/PdoConnectionInterface.php
+++ b/src/Driver/Pdo/PdoConnectionInterface.php
@@ -25,7 +25,7 @@ interface PdoConnectionInterface extends ConnectionInterface
      *
      * @return PDO The {@see PDO} instance for the current connection.
      */
-    public function getActivePdo(string $sql = '', ?bool $forRead = null): PDO;
+    public function getActivePdo(): PDO;
 
     /**
      * The PHP {@see PDO} instance associated with this DB connection.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
