### PR TITLE
Fix Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,6 +6,7 @@ FROM php:8.3-cli-bookworm
 
 RUN apt-get update && apt-get install -y \
     unzip \
+    libicu-dev \
     # PostgreSQL
     libpq-dev \
     # MSSQL
@@ -65,6 +66,8 @@ RUN docker-php-ext-install \
     pdo_mysql \
     pdo_pgsql \
     pcntl \
+    bcmath \
+    intl \
     # For Psalm, to make use of JIT for a 20%+ performance boost.
     opcache
 


### PR DESCRIPTION
```
0.433   Problem 1
0.433     - azjezz/psl is locked to version 3.3.0 and an update of this package was not requested.
0.433     - azjezz/psl 3.3.0 requires ext-bcmath * -> it is missing from your system. Install or enable PHP's bcmath extension.
0.433   Problem 2
0.433     - maglnet/composer-require-checker is locked to version 4.18.0 and an update of this package was not requested.
0.433     - azjezz/psl 3.3.0 requires ext-bcmath * -> it is missing from your system. Install or enable PHP's bcmath extension.
0.433     - maglnet/composer-require-checker 4.18.0 requires azjezz/psl ^3.2.0 -> satisfiable by azjezz/psl[3.3.0].
```

```
0.452   Problem 1
0.452     - azjezz/psl is locked to version 3.3.0 and an update of this package was not requested.
0.452     - azjezz/psl 3.3.0 requires ext-intl * -> it is missing from your system. Install or enable PHP's intl extension.
0.452   Problem 2
0.452     - maglnet/composer-require-checker is locked to version 4.18.0 and an update of this package was not requested.
0.452     - azjezz/psl 3.3.0 requires ext-intl * -> it is missing from your system. Install or enable PHP's intl extension.
0.452     - maglnet/composer-require-checker 4.18.0 requires azjezz/psl ^3.2.0 -> satisfiable by azjezz/psl[3.3.0].
```