### PR TITLE
Fix queryScalar() state mutation by using clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.0.2 under development
 
-- no changes in this release.
+- Enh #1172: Refactor `Query::queryScalar()` to use a cloned `Query` object (@darkspock)
 
 ## 2.0.1 February 09, 2026
 

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -833,24 +833,13 @@ class Query implements QueryInterface
             && empty($this->having)
             && empty($this->union)
         ) {
-            $select = $this->select;
-            $order = $this->orderBy;
-            $limit = $this->limit;
-            $offset = $this->offset;
+            $query = clone $this;
+            $query->select = [$selectExpression];
+            $query->orderBy = [];
+            $query->limit = null;
+            $query->offset = null;
 
-            $this->select = [$selectExpression];
-            $this->orderBy = [];
-            $this->limit = null;
-            $this->offset = null;
-
-            $command = $this->createCommand();
-
-            $this->select = $select;
-            $this->orderBy = $order;
-            $this->limit = $limit;
-            $this->offset = $offset;
-
-            return $command->queryScalar();
+            return $query->createCommand()->queryScalar();
         }
 
         $query = (new self($this->db))->select($selectExpression)->from(['c' => $this]);


### PR DESCRIPTION
## Summary

`Query::queryScalar()` manually saves and restores `select`, `orderBy`, `limit`, and `offset` properties around `createCommand()`. This is fragile:

- If `createCommand()` throws an exception, the original state is **never restored**
- Not safe if properties hold references used elsewhere
- Inconsistent with the `else` branch (line 856) which already creates a new Query instance

### Before
```php
$select = $this->select;
$order = $this->orderBy;
$limit = $this->limit;
$offset = $this->offset;

$this->select = [$selectExpression];
$this->orderBy = [];
$this->limit = null;
$this->offset = null;

$command = $this->createCommand();

$this->select = $select;
$this->orderBy = $order;
$this->limit = $limit;
$this->offset = $offset;

return $command->queryScalar();
```

### After
```php
$query = clone $this;
$query->select = [$selectExpression];
$query->orderBy = [];
$query->limit = null;
$query->offset = null;

return $query->createCommand()->queryScalar();
```

The clone approach is already the established pattern in this codebase (see `withTypecasting()`).

## Risk

Low — the clone produces identical SQL output. The only behavioral change is that the original Query object is no longer temporarily mutated.