### PR TITLE
Fix ConvertException false positives from SQLSTATE[HY match

### DIFF
--- a/src/Exception/ConvertException.php
+++ b/src/Exception/ConvertException.php
@@ -18,7 +18,6 @@ final class ConvertException
 {
     private const MSG_INTEGRITY_EXCEPTION_1 = 'SQLSTATE[23';
     private const MGS_INTEGRITY_EXCEPTION_2 = 'ORA-00001: unique constraint';
-    private const MSG_INTEGRITY_EXCEPTION_3 = 'SQLSTATE[HY';
 
     public function __construct(
         private readonly \Exception $e,
@@ -36,13 +35,31 @@ final class ConvertException
 
         $errorInfo = $this->e instanceof PDOException ? $this->e->errorInfo : null;
 
-        return match (
-            str_contains($message, self::MSG_INTEGRITY_EXCEPTION_1)
+        $isIntegrity = str_contains($message, self::MSG_INTEGRITY_EXCEPTION_1)
             || str_contains($message, self::MGS_INTEGRITY_EXCEPTION_2)
-            || str_contains($message, self::MSG_INTEGRITY_EXCEPTION_3)
-        ) {
+            || $this->isIntegrityConstraintViolation($errorInfo);
+
+        return match ($isIntegrity) {
             true => new IntegrityException($message, $errorInfo, $this->e),
             default => new Exception($message, $errorInfo, $this->e),
         };
+    }
+
+    /**
+     * Checks if the error is an integrity constraint violation using SQLSTATE code.
+     *
+     * SQLSTATE class 23 covers all integrity constraint violations across DBMS.
+     * The previous SQLSTATE[HY match was too broad (HY = CLI-specific condition class)
+     * and could cause false positives.
+     *
+     * @param array|null $errorInfo PDO error info array [SQLSTATE, driver code, message]
+     */
+    private function isIntegrityConstraintViolation(?array $errorInfo): bool
+    {
+        if ($errorInfo === null || !isset($errorInfo[0])) {
+            return false;
+        }
+
+        return str_starts_with((string) $errorInfo[0], '23');
     }
 }


### PR DESCRIPTION
## Summary

`ConvertException::run()` matches `SQLSTATE[HY` in error messages to detect integrity constraint violations. However, SQLSTATE class `HY` is the "CLI-specific condition" class (e.g., `HY000` = general error, `HY001` = memory allocation error, `HY010` = function sequence error). These are **not** integrity constraint violations and should not be wrapped as `IntegrityException`.

This can cause false positives where general database errors are incorrectly classified as integrity violations.

### Fix

- Remove the `SQLSTATE[HY` string match
- Add a proper check using `PDOException::errorInfo[0]` (the SQLSTATE code) for class `23`, which is the standard SQLSTATE class for integrity constraint violations across all DBMS
- Keep the existing `SQLSTATE[23` message string match and `ORA-00001` match as fallbacks

### Before
```php
return match (
    str_contains($message, self::MSG_INTEGRITY_EXCEPTION_1)
    || str_contains($message, self::MGS_INTEGRITY_EXCEPTION_2)
    || str_contains($message, self::MSG_INTEGRITY_EXCEPTION_3) // SQLSTATE[HY — too broad
) {
```

### After
```php
$isIntegrity = str_contains($message, self::MSG_INTEGRITY_EXCEPTION_1)
    || str_contains($message, self::MGS_INTEGRITY_EXCEPTION_2)
    || $this->isIntegrityConstraintViolation($errorInfo); // checks errorInfo[0] starts with '23'
```

## Risk

Low — this makes detection **more precise**. Errors that were previously (incorrectly) classified as `IntegrityException` will now correctly be classified as `Exception`. Code that catches `IntegrityException` specifically will no longer catch unrelated errors.