### PR TITLE
Add table prefix usage instructions

### DIFF
--- a/docs/guide/en/README.md
+++ b/docs/guide/en/README.md
@@ -82,6 +82,8 @@ You can create a database connection instance using a [DI container](https://git
 > When you create a DB connection instance, the actual connection to the database isn't established until
 > you execute the first SQL or call the `Yiisoft\Db\Connection\ConnectionInterface::open()` method explicitly.
 
+[Initialize ConnectionProvider](connection/connection-provider.md) if needed.
+
 ### Table prefix
 
 A connection uses no table prefix by default. If your tables share a prefix, set it after creating the connection:
@@ -101,8 +103,6 @@ $users = $db->createCommand('SELECT * FROM {{%user}}')->queryAll();
 
 In this example, `{{%user}}` resolves to the `app_user` table. The configured prefix isn't applied to table names that
 don't contain `%`.
-
-[Initialize ConnectionProvider](connection/connection-provider.md) if needed.
 
 ### Logger and profiler
 

--- a/docs/guide/en/README.md
+++ b/docs/guide/en/README.md
@@ -82,6 +82,26 @@ You can create a database connection instance using a [DI container](https://git
 > When you create a DB connection instance, the actual connection to the database isn't established until
 > you execute the first SQL or call the `Yiisoft\Db\Connection\ConnectionInterface::open()` method explicitly.
 
+### Table prefix
+
+A connection uses no table prefix by default. If your tables share a prefix, set it after creating the connection:
+
+```php
+use Yiisoft\Db\Connection\ConnectionInterface;
+
+/** @var ConnectionInterface $db */
+$db->setTablePrefix('app_');
+```
+
+Use `%` inside the [special table quoting syntax](#quote-table-and-column-names) to substitute the prefix:
+
+```php
+$users = $db->createCommand('SELECT * FROM {{%user}}')->queryAll();
+```
+
+In this example, `{{%user}}` resolves to the `app_user` table. The configured prefix isn't applied to table names that
+don't contain `%`.
+
 [Initialize ConnectionProvider](connection/connection-provider.md) if needed.
 
 ### Logger and profiler


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | ❌ |
| New feature? | ❌ |
| Docs added? | ✔️ |
| Breaks BC? | ❌ |
| Fixed issues | #1151 |

## Summary

- document the default table prefix and how to configure it on a connection
- show how `%` in the special table quoting syntax resolves to the configured prefix
- clarify that names without `%` do not receive the configured prefix

## Validation

- `QuoterTest`: 13 tests, 15 assertions passed
- runtime check resolved `{{%user}}` to the quoted `app_user` table
- `composer validate --no-check-publish` reports a valid manifest with the existing dependency-constraint warnings
- `git diff --check`

Fixes #1151
