### PR TITLE
fix(schema)!: index schema metadata by table name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Enh #1172: Refactor `Query::queryScalar()` to use a cloned `Query` object (@darkspock)
 - New #1178: Support `UnitEnum` enums as column values (@Tigrov)
+- Bug #1176: Index the result of `AbstractSchema::getSchemaMetadata()` by table name, so `getSchemaChecks()`,
+  `getSchemaDefaultValues()`, `getSchemaForeignKeys()`, `getSchemaIndexes()`, `getSchemaPrimaryKeys()`,
+  `getSchemaUniques()` and `getTableSchemas()` expose the table each item belongs to (@KalimeroMK)
 
 ## 2.0.1 February 09, 2026
 

--- a/src/Constraint/ConstraintSchemaInterface.php
+++ b/src/Constraint/ConstraintSchemaInterface.php
@@ -23,7 +23,9 @@ interface ConstraintSchemaInterface
      * @param bool $refresh Whether to fetch the latest available table schemas. If this is `false`, cached data may be
      * returned if available.
      *
-     * @return Check[] The check constraints for all tables in the database.
+     * @return Check[][] The check constraints for all tables in the database, indexed by table name.
+     *
+     * @psalm-return array<string, Check[]>
      */
     public function getSchemaChecks(string $schema = '', bool $refresh = false): array;
 
@@ -35,7 +37,9 @@ interface ConstraintSchemaInterface
      * @param bool $refresh Whether to fetch the latest available table schemas. If this is `false`, cached data may be
      * returned if available.
      *
-     * @return DefaultValue[] The default value constraints for all tables in the database.
+     * @return DefaultValue[][] The default value constraints for all tables in the database, indexed by table name.
+     *
+     * @psalm-return array<string, DefaultValue[]>
      */
     public function getSchemaDefaultValues(string $schema = '', bool $refresh = false): array;
 
@@ -47,7 +51,10 @@ interface ConstraintSchemaInterface
      * @param bool $refresh Whether to fetch the latest available table schemas. If this is `false`, cached data may be
      * returned if available.
      *
-     * @return ForeignKey[] The foreign keys for all tables in the database.
+     * @return ForeignKey[][] The foreign keys for all tables in the database, indexed by the name of the table the
+     * foreign keys belong to.
+     *
+     * @psalm-return array<string, ForeignKey[]>
      */
     public function getSchemaForeignKeys(string $schema = '', bool $refresh = false): array;
 
@@ -59,7 +66,9 @@ interface ConstraintSchemaInterface
      * @param bool $refresh Whether to fetch the latest available table schemas. If this is false, cached data may be
      * returned if available.
      *
-     * @return Index[] The indexes for all tables in the database.
+     * @return Index[][] The indexes for all tables in the database, indexed by table name.
+     *
+     * @psalm-return array<string, Index[]>
      */
     public function getSchemaIndexes(string $schema = '', bool $refresh = false): array;
 
@@ -71,7 +80,10 @@ interface ConstraintSchemaInterface
      * @param bool $refresh Whether to fetch the latest available table schemas. If this is `false`, cached data may be
      * returned if available.
      *
-     * @return Index[] The primary keys for all tables in the database.
+     * @return Index[] The primary keys for all tables in the database, indexed by table name. Tables without a primary
+     * key are omitted.
+     *
+     * @psalm-return array<string, Index>
      */
     public function getSchemaPrimaryKeys(string $schema = '', bool $refresh = false): array;
 
@@ -83,7 +95,9 @@ interface ConstraintSchemaInterface
      * @param bool $refresh Whether to fetch the latest available table schemas. If this is `false`, cached data may be
      * returned if available.
      *
-     * @return Index[] The unique constraints for all tables in the database.
+     * @return Index[][] The unique constraints for all tables in the database, indexed by table name.
+     *
+     * @psalm-return array<string, Index[]>
      */
     public function getSchemaUniques(string $schema = '', bool $refresh = false): array;
 

--- a/src/Schema/AbstractSchema.php
+++ b/src/Schema/AbstractSchema.php
@@ -410,7 +410,7 @@ abstract class AbstractSchema implements SchemaInterface
      * @return Check[][]|DefaultValue[][]|ForeignKey[][]|Index[]|Index[][]|TableSchemaInterface[] The metadata of the given type for all
      * tables in the given schema, indexed by table name.
      *
-     * @psalm-return array<string, mixed>
+     * @psalm-return array<string, Check[]|DefaultValue[]|ForeignKey[]|Index|Index[]|TableSchemaInterface>
      */
     protected function getSchemaMetadata(string $schema, string $type, bool $refresh): array
     {

--- a/src/Schema/AbstractSchema.php
+++ b/src/Schema/AbstractSchema.php
@@ -110,25 +110,25 @@ abstract class AbstractSchema implements SchemaInterface
 
     public function getSchemaChecks(string $schema = '', bool $refresh = false): array
     {
-        /** @var Check[] */
+        /** @var array<string, Check[]> */
         return $this->getSchemaMetadata($schema, SchemaInterface::CHECKS, $refresh);
     }
 
     public function getSchemaDefaultValues(string $schema = '', bool $refresh = false): array
     {
-        /** @var DefaultValue[] */
+        /** @var array<string, DefaultValue[]> */
         return $this->getSchemaMetadata($schema, SchemaInterface::DEFAULT_VALUES, $refresh);
     }
 
     public function getSchemaForeignKeys(string $schema = '', bool $refresh = false): array
     {
-        /** @var ForeignKey[] */
+        /** @var array<string, ForeignKey[]> */
         return $this->getSchemaMetadata($schema, SchemaInterface::FOREIGN_KEYS, $refresh);
     }
 
     public function getSchemaIndexes(string $schema = '', bool $refresh = false): array
     {
-        /** @var Index[] */
+        /** @var array<string, Index[]> */
         return $this->getSchemaMetadata($schema, SchemaInterface::INDEXES, $refresh);
     }
 
@@ -143,13 +143,13 @@ abstract class AbstractSchema implements SchemaInterface
 
     public function getSchemaPrimaryKeys(string $schema = '', bool $refresh = false): array
     {
-        /** @var Index[] */
+        /** @var array<string, Index> */
         return $this->getSchemaMetadata($schema, SchemaInterface::PRIMARY_KEY, $refresh);
     }
 
     public function getSchemaUniques(string $schema = '', bool $refresh = false): array
     {
-        /** @var Index[] */
+        /** @var array<string, Index[]> */
         return $this->getSchemaMetadata($schema, SchemaInterface::UNIQUES, $refresh);
     }
 
@@ -217,7 +217,7 @@ abstract class AbstractSchema implements SchemaInterface
 
     public function getTableSchemas(string $schema = '', bool $refresh = false): array
     {
-        /** @var TableSchemaInterface[] */
+        /** @var array<string, TableSchemaInterface> */
         return $this->getSchemaMetadata($schema, SchemaInterface::SCHEMA, $refresh);
     }
 
@@ -408,7 +408,9 @@ abstract class AbstractSchema implements SchemaInterface
      * returned if available.
      *
      * @return Check[][]|DefaultValue[][]|ForeignKey[][]|Index[]|Index[][]|TableSchemaInterface[] The metadata of the given type for all
-     * tables in the given schema.
+     * tables in the given schema, indexed by table name.
+     *
+     * @psalm-return array<string, mixed>
      */
     protected function getSchemaMetadata(string $schema, string $type, bool $refresh): array
     {
@@ -416,8 +418,8 @@ abstract class AbstractSchema implements SchemaInterface
         $quoter = $this->db->getQuoter();
         $tableNames = $this->getTableNames($schema, $refresh);
 
-        foreach ($tableNames as $name) {
-            $name = $quoter->quoteSimpleTableName($name);
+        foreach ($tableNames as $tableName) {
+            $name = $quoter->quoteSimpleTableName($tableName);
 
             if ($schema !== '') {
                 $name = $schema . '.' . $name;
@@ -426,7 +428,7 @@ abstract class AbstractSchema implements SchemaInterface
             $tableMetadata = $this->getTableTypeMetadata($type, $name, $refresh);
 
             if ($tableMetadata !== null) {
-                $metadata[] = $tableMetadata;
+                $metadata[$tableName] = $tableMetadata;
             }
         }
 

--- a/src/Schema/SchemaInterface.php
+++ b/src/Schema/SchemaInterface.php
@@ -114,7 +114,9 @@ interface SchemaInterface extends ConstraintSchemaInterface
      * @param bool $refresh Whether to fetch the latest available table schemas. If this is `false`, cached data may be
      * returned if available.
      *
-     * @return TableSchemaInterface[] The metadata for all tables in the database.
+     * @return TableSchemaInterface[] The metadata for all tables in the database, indexed by table name.
+     *
+     * @psalm-return array<string, TableSchemaInterface>
      */
     public function getTableSchemas(string $schema = '', bool $refresh = false): array;
 

--- a/tests/Common/CommonSchemaTest.php
+++ b/tests/Common/CommonSchemaTest.php
@@ -163,12 +163,16 @@ abstract class CommonSchemaTest extends IntegrationTestCase
 
     public function testGetSchemaChecks(): void
     {
+        $this->loadFixture();
+
         $schema = $this->getSharedConnection()->getSchema();
         $tableChecks = $schema->getSchemaChecks();
+        $tableNames = $schema->getTableNames();
 
         $this->assertIsArray($tableChecks);
 
-        foreach ($tableChecks as $checks) {
+        foreach ($tableChecks as $tableName => $checks) {
+            $this->assertContains($tableName, $tableNames);
             $this->assertIsArray($checks);
             $this->assertContainsOnlyInstancesOf(Check::class, $checks);
         }
@@ -176,12 +180,16 @@ abstract class CommonSchemaTest extends IntegrationTestCase
 
     public function testGetSchemaDefaultValues(): void
     {
+        $this->loadFixture();
+
         $schema = $this->getSharedConnection()->getSchema();
         $tableDefaultValues = $schema->getSchemaDefaultValues();
+        $tableNames = $schema->getTableNames();
 
         $this->assertIsArray($tableDefaultValues);
 
-        foreach ($tableDefaultValues as $defaultValues) {
+        foreach ($tableDefaultValues as $tableName => $defaultValues) {
+            $this->assertContains($tableName, $tableNames);
             $this->assertIsArray($defaultValues);
             $this->assertContainsOnlyInstancesOf(DefaultValue::class, $defaultValues);
         }
@@ -189,25 +197,46 @@ abstract class CommonSchemaTest extends IntegrationTestCase
 
     public function testGetSchemaForeignKeys(): void
     {
+        $this->loadFixture();
+
         $schema = $this->getSharedConnection()->getSchema();
         $tableForeignKeys = $schema->getSchemaForeignKeys();
+        $tableNames = $schema->getTableNames();
+
+        $this->assertNotEmpty($tableForeignKeys);
 
         $this->assertIsArray($tableForeignKeys);
 
-        foreach ($tableForeignKeys as $foreignKeys) {
+        foreach ($tableForeignKeys as $tableName => $foreignKeys) {
+            // The result is indexed by the name of the table the foreign keys belong to,
+            // see https://github.com/yiisoft/db/issues/1176
+            $this->assertIsString($tableName);
+            $this->assertContains($tableName, $tableNames);
+
             $this->assertIsArray($foreignKeys);
             $this->assertContainsOnlyInstancesOf(ForeignKey::class, $foreignKeys);
+
+            foreach ($foreignKeys as $foreignKey) {
+                $this->assertNotSame('', $foreignKey->foreignTableName);
+                $this->assertNotSame([], $foreignKey->foreignColumnNames);
+            }
         }
     }
 
     public function testGetSchemaIndexes(): void
     {
+        $this->loadFixture();
+
         $schema = $this->getSharedConnection()->getSchema();
         $tableIndexes = $schema->getSchemaIndexes();
+        $tableNames = $schema->getTableNames();
+
+        $this->assertNotEmpty($tableIndexes);
 
         $this->assertIsArray($tableIndexes);
 
-        foreach ($tableIndexes as $indexes) {
+        foreach ($tableIndexes as $tableName => $indexes) {
+            $this->assertContains($tableName, $tableNames);
             $this->assertIsArray($indexes);
             $this->assertContainsOnlyInstancesOf(Index::class, $indexes);
         }
@@ -215,21 +244,34 @@ abstract class CommonSchemaTest extends IntegrationTestCase
 
     public function testGetSchemaPrimaryKeys(): void
     {
+        $this->loadFixture();
+
         $schema = $this->getSharedConnection()->getSchema();
         $tablePks = $schema->getSchemaPrimaryKeys();
+        $tableNames = $schema->getTableNames();
+
+        $this->assertNotEmpty($tablePks);
 
         $this->assertIsArray($tablePks);
         $this->assertContainsOnlyInstancesOf(Index::class, $tablePks);
+
+        foreach (array_keys($tablePks) as $tableName) {
+            $this->assertContains($tableName, $tableNames);
+        }
     }
 
     public function testGetSchemaUniques(): void
     {
+        $this->loadFixture();
+
         $schema = $this->getSharedConnection()->getSchema();
         $tableUniques = $schema->getSchemaUniques();
+        $tableNames = $schema->getTableNames();
 
         $this->assertIsArray($tableUniques);
 
-        foreach ($tableUniques as $uniques) {
+        foreach ($tableUniques as $tableName => $uniques) {
+            $this->assertContains($tableName, $tableNames);
             $this->assertIsArray($uniques);
             $this->assertContainsOnlyInstancesOf(Index::class, $uniques);
         }

--- a/tests/Db/Schema/SchemaTest.php
+++ b/tests/Db/Schema/SchemaTest.php
@@ -55,7 +55,7 @@ final class SchemaTest extends IntegrationTestCase
         $schemaMock->expects($this->once())->method('loadTableChecks')->willReturn($checks);
         $tableChecks = $schemaMock->getSchemaChecks();
 
-        $this->assertSame([$checks], $tableChecks);
+        $this->assertSame(['T_constraints_1' => $checks], $tableChecks);
     }
 
     public function testGetSchemaDefaultValues(): void
@@ -71,7 +71,7 @@ final class SchemaTest extends IntegrationTestCase
         $schemaMock->expects($this->once())->method('loadTableDefaultValues')->willReturn($defaultValues);
         $tableDefaultValues = $schemaMock->getSchemaDefaultValues();
 
-        $this->assertSame([$defaultValues], $tableDefaultValues);
+        $this->assertSame(['T_constraints_1' => $defaultValues], $tableDefaultValues);
     }
 
     public function testGetSchemaForeignKeys(): void
@@ -93,7 +93,10 @@ final class SchemaTest extends IntegrationTestCase
         $schemaMock->expects($this->once())->method('loadTableForeignKeys')->willReturn($foreignKeys);
         $tableForeignKeys = $schemaMock->getSchemaForeignKeys();
 
-        $this->assertSame([$foreignKeys], $tableForeignKeys);
+        $this->assertSame(['T_constraints_1' => $foreignKeys], $tableForeignKeys);
+        // The result is indexed by the name of the table the foreign keys belong to, see https://github.com/yiisoft/db/issues/1176
+        $this->assertSame(['T_constraints_1'], array_keys($tableForeignKeys));
+        $this->assertSame('T_constraints_2', $tableForeignKeys['T_constraints_1'][0]->foreignTableName);
     }
 
     public function testGetSchemaIndexes(): void
@@ -109,7 +112,7 @@ final class SchemaTest extends IntegrationTestCase
         $schemaMock->expects($this->once())->method('loadTableIndexes')->willReturn($indexes);
         $tableIndexes = $schemaMock->getSchemaIndexes();
 
-        $this->assertSame([$indexes], $tableIndexes);
+        $this->assertSame(['T_constraints_1' => $indexes], $tableIndexes);
     }
 
     public function testGetSchemaNames(): void


### PR DESCRIPTION
getSchemaMetadata() appended per-table results with $metadata[], discarding which table each entry belonged to. Callers of getSchemaForeignKeys() received a flat list of ForeignKey[] groups with no way to map them back to their owning table.

Also corrects @return annotations that documented ForeignKey[] and Index[] for values that have always been arrays of arrays, and loads fixtures in the schema tests, which previously passed vacuously against an empty database.

BREAKING CHANGE: getSchemaChecks(), getSchemaDefaultValues(), getSchemaForeignKeys(), getSchemaIndexes(), getSchemaPrimaryKeys(), getSchemaUniques() and getTableSchemas() return arrays keyed by table name. Iterating with foreach is unaffected; code relying on sequential integer offsets must be updated.

Closes #1176

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
| Tests pass?   | ✔️/❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
