### PR TITLE
Remove unused schema-wide constraint getters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Yii Database Change Log
 
+## 3.0.0 under development
+
+- Chg #1175: Remove `getSchemaChecks()`, `getSchemaDefaultValues()`, `getSchemaIndexes()`, `getSchemaPrimaryKeys()`
+  and `getSchemaUniques()` methods from `ConstraintSchemaInterface` and `AbstractSchema` (@KalimeroMK)
+
 ## 2.0.2 under development
 
 - Enh #1172: Refactor `Query::queryScalar()` to use a cloned `Query` object (@darkspock)

--- a/src/Constraint/ConstraintSchemaInterface.php
+++ b/src/Constraint/ConstraintSchemaInterface.php
@@ -16,34 +16,6 @@ namespace Yiisoft\Db\Constraint;
 interface ConstraintSchemaInterface
 {
     /**
-     * Returns check constraints for all tables in the database.
-     *
-     * @param string $schema The schema of the tables. Defaults to empty string, meaning the current or default schema
-     * name.
-     * @param bool $refresh Whether to fetch the latest available table schemas. If this is `false`, cached data may be
-     * returned if available.
-     *
-     * @return Check[][] The check constraints for all tables in the database, indexed by table name.
-     *
-     * @psalm-return array<string, Check[]>
-     */
-    public function getSchemaChecks(string $schema = '', bool $refresh = false): array;
-
-    /**
-     * Returns default value constraints for all tables in the database.
-     *
-     * @param string $schema The schema of the tables. Defaults to empty string, meaning the current or default schema
-     * name.
-     * @param bool $refresh Whether to fetch the latest available table schemas. If this is `false`, cached data may be
-     * returned if available.
-     *
-     * @return DefaultValue[][] The default value constraints for all tables in the database, indexed by table name.
-     *
-     * @psalm-return array<string, DefaultValue[]>
-     */
-    public function getSchemaDefaultValues(string $schema = '', bool $refresh = false): array;
-
-    /**
      * Returns foreign keys for all tables in the database.
      *
      * @param string $schema The schema of the tables. Defaults to empty string, meaning the current or default schema
@@ -57,49 +29,6 @@ interface ConstraintSchemaInterface
      * @psalm-return array<string, ForeignKey[]>
      */
     public function getSchemaForeignKeys(string $schema = '', bool $refresh = false): array;
-
-    /**
-     * Returns indexes for all tables in the database.
-     *
-     * @param string $schema The schema of the tables. Defaults to empty string, meaning the current or default schema
-     * name.
-     * @param bool $refresh Whether to fetch the latest available table schemas. If this is false, cached data may be
-     * returned if available.
-     *
-     * @return Index[][] The indexes for all tables in the database, indexed by table name.
-     *
-     * @psalm-return array<string, Index[]>
-     */
-    public function getSchemaIndexes(string $schema = '', bool $refresh = false): array;
-
-    /**
-     * Returns primary keys for all tables in the database.
-     *
-     * @param string $schema The schema of the tables. Defaults to empty string, meaning the current or default schema
-     * name.
-     * @param bool $refresh Whether to fetch the latest available table schemas. If this is `false`, cached data may be
-     * returned if available.
-     *
-     * @return Index[] The primary keys for all tables in the database, indexed by table name. Tables without a primary
-     * key are omitted.
-     *
-     * @psalm-return array<string, Index>
-     */
-    public function getSchemaPrimaryKeys(string $schema = '', bool $refresh = false): array;
-
-    /**
-     * Returns unique constraints for all tables in the database.
-     *
-     * @param string $schema The schema of the tables. Defaults to empty string, meaning the current or default schema
-     * name.
-     * @param bool $refresh Whether to fetch the latest available table schemas. If this is `false`, cached data may be
-     * returned if available.
-     *
-     * @return Index[][] The unique constraints for all tables in the database, indexed by table name.
-     *
-     * @psalm-return array<string, Index[]>
-     */
-    public function getSchemaUniques(string $schema = '', bool $refresh = false): array;
 
     /**
      * Obtains the check constraints' information for the named table.

--- a/src/Schema/AbstractSchema.php
+++ b/src/Schema/AbstractSchema.php
@@ -108,28 +108,10 @@ abstract class AbstractSchema implements SchemaInterface
         return $column;
     }
 
-    public function getSchemaChecks(string $schema = '', bool $refresh = false): array
-    {
-        /** @var array<string, Check[]> */
-        return $this->getSchemaMetadata($schema, SchemaInterface::CHECKS, $refresh);
-    }
-
-    public function getSchemaDefaultValues(string $schema = '', bool $refresh = false): array
-    {
-        /** @var array<string, DefaultValue[]> */
-        return $this->getSchemaMetadata($schema, SchemaInterface::DEFAULT_VALUES, $refresh);
-    }
-
     public function getSchemaForeignKeys(string $schema = '', bool $refresh = false): array
     {
         /** @var array<string, ForeignKey[]> */
         return $this->getSchemaMetadata($schema, SchemaInterface::FOREIGN_KEYS, $refresh);
-    }
-
-    public function getSchemaIndexes(string $schema = '', bool $refresh = false): array
-    {
-        /** @var array<string, Index[]> */
-        return $this->getSchemaMetadata($schema, SchemaInterface::INDEXES, $refresh);
     }
 
     public function getSchemaNames(bool $refresh = false): array
@@ -139,18 +121,6 @@ abstract class AbstractSchema implements SchemaInterface
         }
 
         return $this->schemaNames;
-    }
-
-    public function getSchemaPrimaryKeys(string $schema = '', bool $refresh = false): array
-    {
-        /** @var array<string, Index> */
-        return $this->getSchemaMetadata($schema, SchemaInterface::PRIMARY_KEY, $refresh);
-    }
-
-    public function getSchemaUniques(string $schema = '', bool $refresh = false): array
-    {
-        /** @var array<string, Index[]> */
-        return $this->getSchemaMetadata($schema, SchemaInterface::UNIQUES, $refresh);
     }
 
     public function getTableChecks(string $name, bool $refresh = false): array

--- a/src/Schema/AbstractSchema.php
+++ b/src/Schema/AbstractSchema.php
@@ -377,10 +377,11 @@ abstract class AbstractSchema implements SchemaInterface
      * @param bool $refresh Whether to fetch the latest available table metadata. If this is `false`, cached data may be
      * returned if available.
      *
-     * @return Check[][]|DefaultValue[][]|ForeignKey[][]|Index[]|Index[][]|TableSchemaInterface[] The metadata of the given type for all
+     * @return ForeignKey[][]|TableSchemaInterface[] The metadata of the given type for all
      * tables in the given schema, indexed by table name.
      *
-     * @psalm-return array<string, Check[]|DefaultValue[]|ForeignKey[]|Index|Index[]|TableSchemaInterface>
+     * @psalm-param SchemaInterface::FOREIGN_KEYS|SchemaInterface::SCHEMA $type
+     * @psalm-return array<string, ForeignKey[]|TableSchemaInterface>
      */
     protected function getSchemaMetadata(string $schema, string $type, bool $refresh): array
     {

--- a/src/Schema/AbstractSchema.php
+++ b/src/Schema/AbstractSchema.php
@@ -396,6 +396,7 @@ abstract class AbstractSchema implements SchemaInterface
                 $name = $schema . '.' . $name;
             }
 
+            /** @var ForeignKey[]|TableSchemaInterface|null $tableMetadata */
             $tableMetadata = $this->getTableTypeMetadata($type, $name, $refresh);
 
             if ($tableMetadata !== null) {

--- a/src/Schema/AbstractSchema.php
+++ b/src/Schema/AbstractSchema.php
@@ -396,7 +396,6 @@ abstract class AbstractSchema implements SchemaInterface
                 $name = $schema . '.' . $name;
             }
 
-            /** @var ForeignKey[]|TableSchemaInterface|null $tableMetadata */
             $tableMetadata = $this->getTableTypeMetadata($type, $name, $refresh);
 
             if ($tableMetadata !== null) {
@@ -464,21 +463,16 @@ abstract class AbstractSchema implements SchemaInterface
     /**
      * This method returns the desired metadata type for table name (with refresh if needed).
      *
-     * @return Check[]|DefaultValue[]|ForeignKey[]|Index|Index[]|TableSchemaInterface|null
+     * @return ForeignKey[]|TableSchemaInterface|null
      */
     protected function getTableTypeMetadata(
         string $type,
         string $name,
         bool $refresh = false,
-    ): array|Index|TableSchemaInterface|null {
+    ): array|TableSchemaInterface|null {
         return match ($type) {
             SchemaInterface::SCHEMA => $this->getTableSchema($name, $refresh),
-            SchemaInterface::PRIMARY_KEY => $this->getTablePrimaryKey($name, $refresh),
-            SchemaInterface::UNIQUES => $this->getTableUniques($name, $refresh),
             SchemaInterface::FOREIGN_KEYS => $this->getTableForeignKeys($name, $refresh),
-            SchemaInterface::INDEXES => $this->getTableIndexes($name, $refresh),
-            SchemaInterface::DEFAULT_VALUES => $this->getTableDefaultValues($name, $refresh),
-            SchemaInterface::CHECKS => $this->getTableChecks($name, $refresh),
             default => null,
         };
     }

--- a/tests/Common/CommonSchemaTest.php
+++ b/tests/Common/CommonSchemaTest.php
@@ -161,40 +161,6 @@ abstract class CommonSchemaTest extends IntegrationTestCase
         $this->assertNull($schema->getTableSchema('nonexisting_table'));
     }
 
-    public function testGetSchemaChecks(): void
-    {
-        $this->loadFixture();
-
-        $schema = $this->getSharedConnection()->getSchema();
-        $tableChecks = $schema->getSchemaChecks();
-        $tableNames = $schema->getTableNames();
-
-        $this->assertIsArray($tableChecks);
-
-        foreach ($tableChecks as $tableName => $checks) {
-            $this->assertContains($tableName, $tableNames);
-            $this->assertIsArray($checks);
-            $this->assertContainsOnlyInstancesOf(Check::class, $checks);
-        }
-    }
-
-    public function testGetSchemaDefaultValues(): void
-    {
-        $this->loadFixture();
-
-        $schema = $this->getSharedConnection()->getSchema();
-        $tableDefaultValues = $schema->getSchemaDefaultValues();
-        $tableNames = $schema->getTableNames();
-
-        $this->assertIsArray($tableDefaultValues);
-
-        foreach ($tableDefaultValues as $tableName => $defaultValues) {
-            $this->assertContains($tableName, $tableNames);
-            $this->assertIsArray($defaultValues);
-            $this->assertContainsOnlyInstancesOf(DefaultValue::class, $defaultValues);
-        }
-    }
-
     public function testGetSchemaForeignKeys(): void
     {
         $this->loadFixture();
@@ -220,60 +186,6 @@ abstract class CommonSchemaTest extends IntegrationTestCase
                 $this->assertNotSame('', $foreignKey->foreignTableName);
                 $this->assertNotSame([], $foreignKey->foreignColumnNames);
             }
-        }
-    }
-
-    public function testGetSchemaIndexes(): void
-    {
-        $this->loadFixture();
-
-        $schema = $this->getSharedConnection()->getSchema();
-        $tableIndexes = $schema->getSchemaIndexes();
-        $tableNames = $schema->getTableNames();
-
-        $this->assertNotEmpty($tableIndexes);
-
-        $this->assertIsArray($tableIndexes);
-
-        foreach ($tableIndexes as $tableName => $indexes) {
-            $this->assertContains($tableName, $tableNames);
-            $this->assertIsArray($indexes);
-            $this->assertContainsOnlyInstancesOf(Index::class, $indexes);
-        }
-    }
-
-    public function testGetSchemaPrimaryKeys(): void
-    {
-        $this->loadFixture();
-
-        $schema = $this->getSharedConnection()->getSchema();
-        $tablePks = $schema->getSchemaPrimaryKeys();
-        $tableNames = $schema->getTableNames();
-
-        $this->assertNotEmpty($tablePks);
-
-        $this->assertIsArray($tablePks);
-        $this->assertContainsOnlyInstancesOf(Index::class, $tablePks);
-
-        foreach (array_keys($tablePks) as $tableName) {
-            $this->assertContains($tableName, $tableNames);
-        }
-    }
-
-    public function testGetSchemaUniques(): void
-    {
-        $this->loadFixture();
-
-        $schema = $this->getSharedConnection()->getSchema();
-        $tableUniques = $schema->getSchemaUniques();
-        $tableNames = $schema->getTableNames();
-
-        $this->assertIsArray($tableUniques);
-
-        foreach ($tableUniques as $tableName => $uniques) {
-            $this->assertContains($tableName, $tableNames);
-            $this->assertIsArray($uniques);
-            $this->assertContainsOnlyInstancesOf(Index::class, $uniques);
         }
     }
 

--- a/tests/Db/Schema/SchemaTest.php
+++ b/tests/Db/Schema/SchemaTest.php
@@ -64,7 +64,6 @@ final class SchemaTest extends IntegrationTestCase
         $this->assertSame(['T_constraints_1' => $foreignKeys], $tableForeignKeys);
         // The result is indexed by the name of the table the foreign keys belong to, see https://github.com/yiisoft/db/issues/1176
         $this->assertSame(['T_constraints_1'], array_keys($tableForeignKeys));
-        $this->assertSame('T_constraints_2', $tableForeignKeys['T_constraints_1'][0]->foreignTableName);
     }
 
     public function testGetTableChecks(): void

--- a/tests/Db/Schema/SchemaTest.php
+++ b/tests/Db/Schema/SchemaTest.php
@@ -62,8 +62,6 @@ final class SchemaTest extends IntegrationTestCase
         $tableForeignKeys = $schemaMock->getSchemaForeignKeys();
 
         $this->assertSame(['T_constraints_1' => $foreignKeys], $tableForeignKeys);
-        // The result is indexed by the name of the table the foreign keys belong to, see https://github.com/yiisoft/db/issues/1176
-        $this->assertSame(['T_constraints_1'], array_keys($tableForeignKeys));
     }
 
     public function testGetTableChecks(): void

--- a/tests/Db/Schema/SchemaTest.php
+++ b/tests/Db/Schema/SchemaTest.php
@@ -6,7 +6,9 @@ namespace Yiisoft\Db\Tests\Db\Schema;
 
 use Yiisoft\Db\Cache\SchemaCache;
 use Yiisoft\Db\Constraint\Check;
+use Yiisoft\Db\Constraint\DefaultValue;
 use Yiisoft\Db\Constraint\ForeignKey;
+use Yiisoft\Db\Constraint\Index;
 use Yiisoft\Db\Exception\NotSupportedException;
 use Yiisoft\Db\Schema\Column\ColumnBuilder;
 use Yiisoft\Db\Schema\TableSchema;
@@ -63,6 +65,48 @@ final class SchemaTest extends IntegrationTestCase
         // The result is indexed by the name of the table the foreign keys belong to, see https://github.com/yiisoft/db/issues/1176
         $this->assertSame(['T_constraints_1'], array_keys($tableForeignKeys));
         $this->assertSame('T_constraints_2', $tableForeignKeys['T_constraints_1'][0]->foreignTableName);
+    }
+
+    public function testGetTableChecks(): void
+    {
+        $db = $this->getSharedConnection();
+
+        $checks = [new Check('check_1', ['col1', 'col2'], 'col1 > col2')];
+        $schemaMock = $this->getMockBuilder(Schema::class)
+            ->onlyMethods(['loadTableChecks'])
+            ->setConstructorArgs([$db, TestHelper::createMemorySchemaCache()])
+            ->getMock();
+        $schemaMock->expects($this->once())->method('loadTableChecks')->willReturn($checks);
+
+        $this->assertSame($checks, $schemaMock->getTableChecks('T_constraints_1'));
+    }
+
+    public function testGetTableDefaultValues(): void
+    {
+        $db = $this->getSharedConnection();
+
+        $defaultValues = [new DefaultValue('df_1', ['col1'], 42)];
+        $schemaMock = $this->getMockBuilder(Schema::class)
+            ->onlyMethods(['loadTableDefaultValues'])
+            ->setConstructorArgs([$db, TestHelper::createMemorySchemaCache()])
+            ->getMock();
+        $schemaMock->expects($this->once())->method('loadTableDefaultValues')->willReturn($defaultValues);
+
+        $this->assertSame($defaultValues, $schemaMock->getTableDefaultValues('T_constraints_1'));
+    }
+
+    public function testGetTableIndexes(): void
+    {
+        $db = $this->getSharedConnection();
+
+        $indexes = [new Index('PK__T_constr__A9FAE80AC2B18E65', ['C_id'], true, true)];
+        $schemaMock = $this->getMockBuilder(Schema::class)
+            ->onlyMethods(['loadTableIndexes'])
+            ->setConstructorArgs([$db, TestHelper::createMemorySchemaCache()])
+            ->getMock();
+        $schemaMock->expects($this->once())->method('loadTableIndexes')->willReturn($indexes);
+
+        $this->assertSame($indexes, $schemaMock->getTableIndexes('T_constraints_1'));
     }
 
     public function testGetSchemaNames(): void

--- a/tests/Db/Schema/SchemaTest.php
+++ b/tests/Db/Schema/SchemaTest.php
@@ -6,9 +6,7 @@ namespace Yiisoft\Db\Tests\Db\Schema;
 
 use Yiisoft\Db\Cache\SchemaCache;
 use Yiisoft\Db\Constraint\Check;
-use Yiisoft\Db\Constraint\DefaultValue;
 use Yiisoft\Db\Constraint\ForeignKey;
-use Yiisoft\Db\Constraint\Index;
 use Yiisoft\Db\Exception\NotSupportedException;
 use Yiisoft\Db\Schema\Column\ColumnBuilder;
 use Yiisoft\Db\Schema\TableSchema;
@@ -42,38 +40,6 @@ final class SchemaTest extends IntegrationTestCase
         $this->assertSame([], Assert::invokeMethod($schema, 'findViewNames', ['dbo']));
     }
 
-    public function testGetSchemaChecks(): void
-    {
-        $db = $this->getSharedConnection();
-
-        $checks = [new Check('check_1', ['col1', 'col2'], 'col1 > col2')];
-        $schemaMock = $this->getMockBuilder(Schema::class)
-            ->onlyMethods(['findTableNames', 'loadTableChecks'])
-            ->setConstructorArgs([$db, TestHelper::createMemorySchemaCache()])
-            ->getMock();
-        $schemaMock->expects($this->once())->method('findTableNames')->willReturn(['T_constraints_1']);
-        $schemaMock->expects($this->once())->method('loadTableChecks')->willReturn($checks);
-        $tableChecks = $schemaMock->getSchemaChecks();
-
-        $this->assertSame(['T_constraints_1' => $checks], $tableChecks);
-    }
-
-    public function testGetSchemaDefaultValues(): void
-    {
-        $db = $this->getSharedConnection();
-
-        $defaultValues = [new DefaultValue('DF__T_constra__C_def__6203C3C6', ['C_default'], '((0))')];
-        $schemaMock = $this->getMockBuilder(Schema::class)
-            ->onlyMethods(['findTableNames', 'loadTableDefaultValues'])
-            ->setConstructorArgs([$db, TestHelper::createMemorySchemaCache()])
-            ->getMock();
-        $schemaMock->expects($this->once())->method('findTableNames')->willReturn(['T_constraints_1']);
-        $schemaMock->expects($this->once())->method('loadTableDefaultValues')->willReturn($defaultValues);
-        $tableDefaultValues = $schemaMock->getSchemaDefaultValues();
-
-        $this->assertSame(['T_constraints_1' => $defaultValues], $tableDefaultValues);
-    }
-
     public function testGetSchemaForeignKeys(): void
     {
         $db = $this->getSharedConnection();
@@ -97,22 +63,6 @@ final class SchemaTest extends IntegrationTestCase
         // The result is indexed by the name of the table the foreign keys belong to, see https://github.com/yiisoft/db/issues/1176
         $this->assertSame(['T_constraints_1'], array_keys($tableForeignKeys));
         $this->assertSame('T_constraints_2', $tableForeignKeys['T_constraints_1'][0]->foreignTableName);
-    }
-
-    public function testGetSchemaIndexes(): void
-    {
-        $db = $this->getSharedConnection();
-
-        $indexes = [new Index('PK__T_constr__A9FAE80AC2B18E65', ['"C_id'], true, true)];
-        $schemaMock = $this->getMockBuilder(Schema::class)
-            ->onlyMethods(['findTableNames', 'loadTableIndexes'])
-            ->setConstructorArgs([$db, TestHelper::createMemorySchemaCache()])
-            ->getMock();
-        $schemaMock->expects($this->once())->method('findTableNames')->willReturn(['T_constraints_1']);
-        $schemaMock->expects($this->once())->method('loadTableIndexes')->willReturn($indexes);
-        $tableIndexes = $schemaMock->getSchemaIndexes();
-
-        $this->assertSame(['T_constraints_1' => $indexes], $tableIndexes);
     }
 
     public function testGetSchemaNames(): void
@@ -144,44 +94,6 @@ final class SchemaTest extends IntegrationTestCase
         $this->assertTrue($schema->hasSchema('dbo'));
         $this->assertTrue($schema->hasSchema('public'));
         $this->assertFalse($schema->hasSchema('no_such_schema'));
-    }
-
-    public function testGetSchemaPrimaryKeys(): void
-    {
-        $db = $this->getSharedConnection();
-
-        $pksConstraint = new Index('PK__T_constr__A9FAE80AC2B18E65', ['"C_id'], true, true);
-        $schemaMock = $this->getMockBuilder(Schema::class)
-            ->onlyMethods(['findTableNames', 'getTablePrimaryKey'])
-            ->setConstructorArgs([$db, TestHelper::createMemorySchemaCache()])
-            ->getMock();
-        $schemaMock->expects($this->once())->method('findTableNames')->willReturn(['T_constraints_1']);
-        $schemaMock->expects($this->once())->method('getTablePrimaryKey')->willReturn($pksConstraint);
-        $tablePks = $schemaMock->getSchemaPrimaryKeys();
-
-        $this->assertIsArray($tablePks);
-        $this->assertContainsOnlyInstancesOf(Index::class, $tablePks);
-    }
-
-    public function testGetSchemaUniques(): void
-    {
-        $db = $this->getSharedConnection();
-
-        $uniquesConstraint = [new Index('CN_unique', ['C_unique'], true)];
-        $schemaMock = $this->getMockBuilder(Schema::class)
-            ->onlyMethods(['findTableNames', 'getTableUniques'])
-            ->setConstructorArgs([$db, TestHelper::createMemorySchemaCache()])
-            ->getMock();
-        $schemaMock->expects($this->once())->method('findTableNames')->willReturn(['T_constraints_1']);
-        $schemaMock->expects($this->once())->method('getTableUniques')->willReturn($uniquesConstraint);
-        $tableUniques = $schemaMock->getSchemaUniques();
-
-        $this->assertIsArray($tableUniques);
-
-        foreach ($tableUniques as $uniques) {
-            $this->assertIsArray($uniques);
-            $this->assertContainsOnlyInstancesOf(Index::class, $uniques);
-        }
     }
 
     public function getTableSchema(): void


### PR DESCRIPTION
Removes `getSchemaChecks()`, `getSchemaDefaultValues()`, `getSchemaIndexes()`, `getSchemaPrimaryKeys()` and `getSchemaUniques()` from `ConstraintSchemaInterface` and `AbstractSchema`.

`getSchemaForeignKeys()` is kept, since it is not in the list in #1175 and #1176 asks to improve it — tell me if it should go too. `getSchemaMetadata()` is kept as well, because `getTableSchemas()` still uses it.

The companions need to land together, otherwise the driver testsuites here fail: yiisoft/db-mysql#477, yiisoft/db-pgsql#502, yiisoft/db-oracle#407. yiisoft/db-sqlite#428 is independent cleanup.

`roave_bc_check` is red by design: it reports the five removed methods on both classes, plus the narrowed return type of the protected `AbstractSchema::getTableTypeMetadata()` (its dead match arms for the removed schema-wide getters were dropped; only caller is `getSchemaMetadata()`, which now accepts just `FOREIGN_KEYS|SCHEMA`).

The CHANGELOG entry went under a new `3.0.0 under development` heading to match the milestone, but there is no `3.0` branch yet — happy to move it.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | #1175
