### PR TITLE
New #1152: Add `UuidValue` expression for DBMS-independent UUID values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   `getSchemaDefaultValues()`, `getSchemaForeignKeys()`, `getSchemaIndexes()`, `getSchemaPrimaryKeys()`,
   `getSchemaUniques()` and `getTableSchemas()` expose the table each item belongs to (@KalimeroMK)
 - New #1152: Add `UuidValue` expression that represents a UUID value independently of DBMS (@KalimeroMK)
+- Enh #1152: Improve the exception message of `DbUuidHelper::toUuid()` when the value isn't a valid UUID
+  (@KalimeroMK)
 
 ## 2.0.1 February 09, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Bug #1176: Index the result of `AbstractSchema::getSchemaMetadata()` by table name, so `getSchemaChecks()`,
   `getSchemaDefaultValues()`, `getSchemaForeignKeys()`, `getSchemaIndexes()`, `getSchemaPrimaryKeys()`,
   `getSchemaUniques()` and `getTableSchemas()` expose the table each item belongs to (@KalimeroMK)
+- New #1152: Add `UuidValue` expression that represents a UUID value independently of DBMS (@KalimeroMK)
 
 ## 2.0.1 February 09, 2026
 

--- a/src/Expression/Value/Builder/UuidValueBuilder.php
+++ b/src/Expression/Value/Builder/UuidValueBuilder.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Db\Expression\Value\Builder;
+
+use Yiisoft\Db\Expression\ExpressionBuilderInterface;
+use Yiisoft\Db\Expression\ExpressionInterface;
+use Yiisoft\Db\Expression\Value\UuidValue;
+use Yiisoft\Db\QueryBuilder\QueryBuilderInterface;
+use Yiisoft\Db\Helper\DbUuidHelper;
+
+/**
+ * Builder for {@see UuidValue} expressions.
+ *
+ * Binds the UUID in the canonical string form, which is what PostgreSQL `uuid` and MSSQL `uniqueidentifier` columns
+ * expect. DBMS that store a UUID as raw bytes, such as MySQL, MariaDB, SQLite and Oracle, override
+ * {@see prepareValue()} to convert the value with {@see DbUuidHelper::uuidToBlob()}.
+ *
+ * @implements ExpressionBuilderInterface<UuidValue>
+ */
+class UuidValueBuilder implements ExpressionBuilderInterface
+{
+    /**
+     * @param QueryBuilderInterface $queryBuilder The query builder instance.
+     */
+    public function __construct(
+        protected readonly QueryBuilderInterface $queryBuilder,
+    ) {}
+
+    public function build(ExpressionInterface $expression, array &$params = []): string
+    {
+        return $this->queryBuilder->buildValue($this->prepareValue($expression), $params);
+    }
+
+    /**
+     * Converts the UUID to the representation expected by the DBMS.
+     *
+     * @param UuidValue $expression The expression to convert.
+     *
+     * @return mixed The value to bind, it's passed to {@see QueryBuilderInterface::buildValue()}.
+     */
+    protected function prepareValue(UuidValue $expression): mixed
+    {
+        return $expression->value;
+    }
+}

--- a/src/Expression/Value/Builder/UuidValueBuilder.php
+++ b/src/Expression/Value/Builder/UuidValueBuilder.php
@@ -4,18 +4,21 @@ declare(strict_types=1);
 
 namespace Yiisoft\Db\Expression\Value\Builder;
 
+use Yiisoft\Db\Constant\DataType;
 use Yiisoft\Db\Expression\ExpressionBuilderInterface;
 use Yiisoft\Db\Expression\ExpressionInterface;
+use Yiisoft\Db\Expression\Value\Param;
 use Yiisoft\Db\Expression\Value\UuidValue;
-use Yiisoft\Db\QueryBuilder\QueryBuilderInterface;
 use Yiisoft\Db\Helper\DbUuidHelper;
+use Yiisoft\Db\QueryBuilder\QueryBuilderInterface;
 
 /**
  * Builder for {@see UuidValue} expressions.
  *
- * Binds the UUID in the canonical string form, which is what PostgreSQL `uuid` and MSSQL `uniqueidentifier` columns
- * expect. DBMS that store a UUID as raw bytes, such as MySQL, MariaDB, SQLite and Oracle, override
- * {@see prepareValue()} to convert the value with {@see DbUuidHelper::uuidToBlob()}.
+ * Binds the UUID as a string parameter in the canonical form, which is what PostgreSQL `uuid` and MSSQL
+ * `uniqueidentifier` columns expect. DBMS that store a UUID as raw bytes, such as MySQL, MariaDB, SQLite and Oracle,
+ * override {@see prepareValue()} to convert the value with {@see DbUuidHelper::uuidToBlob()} and bind it as
+ * {@see DataType::LOB}, so the driver sends it as binary rather than as a character string.
  *
  * @implements ExpressionBuilderInterface<UuidValue>
  */
@@ -34,14 +37,14 @@ class UuidValueBuilder implements ExpressionBuilderInterface
     }
 
     /**
-     * Converts the UUID to the representation expected by the DBMS.
+     * Converts the UUID to the parameter expected by the DBMS.
      *
      * @param UuidValue $expression The expression to convert.
      *
-     * @return mixed The value to bind, it's passed to {@see QueryBuilderInterface::buildValue()}.
+     * @return Param The parameter to bind, it's passed to {@see QueryBuilderInterface::buildValue()}.
      */
-    protected function prepareValue(UuidValue $expression): mixed
+    protected function prepareValue(UuidValue $expression): Param
     {
-        return $expression->value;
+        return new Param($expression->value, DataType::STRING);
     }
 }

--- a/src/Expression/Value/UuidValue.php
+++ b/src/Expression/Value/UuidValue.php
@@ -50,13 +50,6 @@ final class UuidValue implements ExpressionInterface
      */
     public function __construct(string|Stringable $value)
     {
-        try {
-            $this->value = strtolower(DbUuidHelper::toUuid((string) $value));
-        } catch (InvalidArgumentException $e) {
-            throw new InvalidArgumentException(
-                'Value is not a valid UUID. Expected the canonical form, 32 hexadecimal characters or 16 raw bytes.',
-                previous: $e,
-            );
-        }
+        $this->value = strtolower(DbUuidHelper::toUuid((string) $value));
     }
 }

--- a/src/Expression/Value/UuidValue.php
+++ b/src/Expression/Value/UuidValue.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Db\Expression\Value;
+
+use InvalidArgumentException;
+use Stringable;
+use Yiisoft\Db\Expression\ExpressionInterface;
+use Yiisoft\Db\Helper\DbUuidHelper;
+
+use function strtolower;
+
+/**
+ * Represents a UUID value that should be stored in a DBMS-independent way.
+ *
+ * Different DBMS expect different representations of the same UUID: MySQL, MariaDB, SQLite and Oracle store it as 16
+ * raw bytes, while PostgreSQL and MSSQL expect the canonical string form. Wrapping the value removes the need to know
+ * which one the current connection requires:
+ *
+ * ```php
+ * $db->createCommand()->insert('{{%page}}', [
+ *     'id' => new UuidValue(Uuid::uuid7()),
+ * ])->execute();
+ * ```
+ *
+ * The value is normalized to the canonical lowercase form on construction, so all of the following are equivalent:
+ *
+ * ```php
+ * new UuidValue('738146be-87b1-49f2-9913-36142fb6fcbe');
+ * new UuidValue('738146be87b149f2991336142fb6fcbe');
+ * new UuidValue(hex2bin('738146be87b149f2991336142fb6fcbe'));
+ * ```
+ */
+final class UuidValue implements ExpressionInterface
+{
+    /**
+     * The UUID in the canonical lowercase form, for example `738146be-87b1-49f2-9913-36142fb6fcbe`.
+     */
+    public readonly string $value;
+
+    /**
+     * @param string|Stringable $value The UUID to represent. It can be:
+     * - a UUID in the canonical form, for example `738146be-87b1-49f2-9913-36142fb6fcbe`;
+     * - a UUID as 32 hexadecimal characters without dashes, for example `738146be87b149f2991336142fb6fcbe`;
+     * - a UUID as 16 raw bytes, for example the result of `Ramsey\Uuid\UuidInterface::getBytes()`;
+     * - any {@see Stringable} instance that returns one of the above, for example `Ramsey\Uuid\UuidInterface` itself.
+     *
+     * @throws InvalidArgumentException If the value isn't a valid UUID.
+     */
+    public function __construct(string|Stringable $value)
+    {
+        try {
+            $this->value = strtolower(DbUuidHelper::toUuid((string) $value));
+        } catch (InvalidArgumentException $e) {
+            throw new InvalidArgumentException(
+                'Value is not a valid UUID. Expected the canonical form, 32 hexadecimal characters or 16 raw bytes.',
+                previous: $e,
+            );
+        }
+    }
+}

--- a/src/Helper/DbUuidHelper.php
+++ b/src/Helper/DbUuidHelper.php
@@ -25,7 +25,9 @@ final class DbUuidHelper
         } elseif (strlen($blobString) === 32 && self::isValidHexUuid($blobString)) {
             $hex = $blobString;
         } else {
-            throw new InvalidArgumentException('Length of source data is should be 16 or 32 bytes.');
+            throw new InvalidArgumentException(
+                'Value is not a valid UUID. Expected the canonical form, 32 hexadecimal characters or 16 raw bytes.',
+            );
         }
 
         return

--- a/src/QueryBuilder/AbstractDQLQueryBuilder.php
+++ b/src/QueryBuilder/AbstractDQLQueryBuilder.php
@@ -38,6 +38,8 @@ use Yiisoft\Db\Expression\Value\Value;
 use Yiisoft\Db\Expression\Value\Builder\ValueBuilder;
 use Yiisoft\Db\Expression\Value\DateTimeValue;
 use Yiisoft\Db\Expression\Value\Builder\DateTimeValueBuilder;
+use Yiisoft\Db\Expression\Value\UuidValue;
+use Yiisoft\Db\Expression\Value\Builder\UuidValueBuilder;
 use Yiisoft\Db\QueryBuilder\Condition\ConditionInterface;
 use Yiisoft\Db\QueryBuilder\Condition\Simple;
 use Yiisoft\Db\Query\Query;
@@ -591,6 +593,7 @@ abstract class AbstractDQLQueryBuilder implements DQLQueryBuilderInterface
             ColumnName::class => ColumnNameBuilder::class,
             Value::class => ValueBuilder::class,
             DateTimeValue::class => DateTimeValueBuilder::class,
+            UuidValue::class => UuidValueBuilder::class,
             Length::class => LengthBuilder::class,
             Greatest::class => GreatestBuilder::class,
             Least::class => LeastBuilder::class,

--- a/tests/Db/Command/CommandTest.php
+++ b/tests/Db/Command/CommandTest.php
@@ -9,6 +9,7 @@ use Yiisoft\Db\Constant\ColumnType;
 use Yiisoft\Db\Constant\PseudoType;
 use Yiisoft\Db\Exception\NotSupportedException;
 use Yiisoft\Db\Expression\Expression;
+use Yiisoft\Db\Expression\Value\UuidValue;
 use Yiisoft\Db\Schema\Column\ColumnBuilder;
 use Yiisoft\Db\Schema\Column\ColumnInterface;
 use Yiisoft\Db\Schema\Column\IntegerColumn;
@@ -524,6 +525,26 @@ final class CommandTest extends IntegrationTestCase
                 ':qp0' => 't1@example.com',
                 ':qp1' => 'test',
                 ':qp2' => 'test address',
+            ],
+            $command->getParams(),
+        );
+    }
+
+    public function testInsertUuid(): void
+    {
+        $db = TestHelper::createSqliteMemoryConnection();
+
+        $command = $db->createCommand();
+        $command->insert('page', ['id' => new UuidValue('738146be-87b1-49f2-9913-36142fb6fcbe'), 'title' => 'test']);
+
+        $this->assertSame(
+            'INSERT INTO [page] ([id], [title]) VALUES (:qp0, :qp1)',
+            $command->getSql(),
+        );
+        $this->assertSame(
+            [
+                ':qp0' => '738146be-87b1-49f2-9913-36142fb6fcbe',
+                ':qp1' => 'test',
             ],
             $command->getParams(),
         );

--- a/tests/Db/Expression/Value/Builder/UuidValueBuilderTest.php
+++ b/tests/Db/Expression/Value/Builder/UuidValueBuilderTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Db\Tests\Db\Expression\Value\Builder;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Db\Constant\DataType;
+use Yiisoft\Db\Expression\Value\Builder\UuidValueBuilder;
+use Yiisoft\Db\Expression\Value\Param;
+use Yiisoft\Db\Expression\Value\UuidValue;
+use Yiisoft\Db\Helper\DbUuidHelper;
+use Yiisoft\Db\Tests\Support\TestHelper;
+
+/**
+ * @group db
+ */
+final class UuidValueBuilderTest extends TestCase
+{
+    private const UUID = '738146be-87b1-49f2-9913-36142fb6fcbe';
+
+    public function testBuild(): void
+    {
+        $db = TestHelper::createSqliteMemoryConnection();
+        $builder = new UuidValueBuilder($db->getQueryBuilder());
+
+        $params = [];
+        $result = $builder->build(new UuidValue(self::UUID), $params);
+
+        $this->assertSame(':qp0', $result);
+        $this->assertEquals([':qp0' => new Param(self::UUID, DataType::STRING)], $params);
+    }
+
+    public function testBuildAppendsToExistingParams(): void
+    {
+        $db = TestHelper::createSqliteMemoryConnection();
+        $builder = new UuidValueBuilder($db->getQueryBuilder());
+
+        $params = [':qp0' => new Param('existing', DataType::STRING)];
+        $result = $builder->build(new UuidValue(self::UUID), $params);
+
+        $this->assertSame(':qp1', $result);
+        $this->assertEquals(
+            [':qp0' => new Param('existing', DataType::STRING), ':qp1' => new Param(self::UUID, DataType::STRING)],
+            $params,
+        );
+    }
+
+    /**
+     * DBMS that store a UUID as raw bytes override {@see UuidValueBuilder::prepareValue()}.
+     */
+    public function testPrepareValueIsOverridable(): void
+    {
+        $db = TestHelper::createSqliteMemoryConnection();
+        $builder = new class ($db->getQueryBuilder()) extends UuidValueBuilder {
+            protected function prepareValue(UuidValue $expression): mixed
+            {
+                return new Param(DbUuidHelper::uuidToBlob($expression->value), DataType::LOB);
+            }
+        };
+
+        $params = [];
+        $result = $builder->build(new UuidValue(self::UUID), $params);
+
+        $this->assertSame(':qp0', $result);
+        $this->assertEquals(
+            [':qp0' => new Param(DbUuidHelper::uuidToBlob(self::UUID), DataType::LOB)],
+            $params,
+        );
+    }
+}

--- a/tests/Db/Expression/Value/Builder/UuidValueBuilderTest.php
+++ b/tests/Db/Expression/Value/Builder/UuidValueBuilderTest.php
@@ -9,7 +9,6 @@ use Yiisoft\Db\Constant\DataType;
 use Yiisoft\Db\Expression\Value\Builder\UuidValueBuilder;
 use Yiisoft\Db\Expression\Value\Param;
 use Yiisoft\Db\Expression\Value\UuidValue;
-use Yiisoft\Db\Helper\DbUuidHelper;
 use Yiisoft\Db\Tests\Support\TestHelper;
 
 /**
@@ -42,29 +41,6 @@ final class UuidValueBuilderTest extends TestCase
         $this->assertSame(':qp1', $result);
         $this->assertEquals(
             [':qp0' => new Param('existing', DataType::STRING), ':qp1' => new Param(self::UUID, DataType::STRING)],
-            $params,
-        );
-    }
-
-    /**
-     * DBMS that store a UUID as raw bytes override {@see UuidValueBuilder::prepareValue()}.
-     */
-    public function testPrepareValueIsOverridable(): void
-    {
-        $db = TestHelper::createSqliteMemoryConnection();
-        $builder = new class ($db->getQueryBuilder()) extends UuidValueBuilder {
-            protected function prepareValue(UuidValue $expression): Param
-            {
-                return new Param(DbUuidHelper::uuidToBlob($expression->value), DataType::LOB);
-            }
-        };
-
-        $params = [];
-        $result = $builder->build(new UuidValue(self::UUID), $params);
-
-        $this->assertSame(':qp0', $result);
-        $this->assertEquals(
-            [':qp0' => new Param(DbUuidHelper::uuidToBlob(self::UUID), DataType::LOB)],
             $params,
         );
     }

--- a/tests/Db/Expression/Value/Builder/UuidValueBuilderTest.php
+++ b/tests/Db/Expression/Value/Builder/UuidValueBuilderTest.php
@@ -53,7 +53,7 @@ final class UuidValueBuilderTest extends TestCase
     {
         $db = TestHelper::createSqliteMemoryConnection();
         $builder = new class ($db->getQueryBuilder()) extends UuidValueBuilder {
-            protected function prepareValue(UuidValue $expression): mixed
+            protected function prepareValue(UuidValue $expression): Param
             {
                 return new Param(DbUuidHelper::uuidToBlob($expression->value), DataType::LOB);
             }

--- a/tests/Db/Expression/Value/UuidValueTest.php
+++ b/tests/Db/Expression/Value/UuidValueTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Db\Tests\Db\Expression\Value;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Stringable;
+use Yiisoft\Db\Expression\Value\UuidValue;
+use Yiisoft\Db\Tests\Support\Stringable as StringableObject;
+
+use function hex2bin;
+
+final class UuidValueTest extends TestCase
+{
+    private const UUID = '738146be-87b1-49f2-9913-36142fb6fcbe';
+
+    public static function values(): iterable
+    {
+        yield 'canonical' => [self::UUID];
+        yield 'canonical in upper case' => ['738146BE-87B1-49F2-9913-36142FB6FCBE'];
+        yield 'hexadecimal' => ['738146be87b149f2991336142fb6fcbe'];
+        yield 'hexadecimal in upper case' => ['738146BE87B149F2991336142FB6FCBE'];
+        yield 'bytes' => [hex2bin('738146be87b149f2991336142fb6fcbe')];
+        yield 'stringable' => [new StringableObject(self::UUID)];
+    }
+
+    #[DataProvider('values')]
+    public function testValueIsNormalized(string|Stringable $value): void
+    {
+        $expression = new UuidValue($value);
+
+        $this->assertSame(self::UUID, $expression->value);
+    }
+
+    public static function invalidValues(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'misplaced dash' => ['738146be-87b149f2-9913-36142fb6fcbe'];
+        yield 'not hexadecimal' => ['738146be-87b1-K9f2-9913-36142fb6fcbe'];
+        yield 'wrong separator' => ['738146be+87b1-49f2-9913-36142fb6fcbe'];
+        yield 'too short' => ['738146be87b149f2991336142fb6fcb'];
+        yield '32 characters but not hexadecimal' => ['zzz146be87b149f2991336142fb6fcbe'];
+    }
+
+    #[DataProvider('invalidValues')]
+    public function testConstructWithInvalidValue(string $value): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Value is not a valid UUID. Expected the canonical form, 32 hexadecimal characters or 16 raw bytes.',
+        );
+
+        new UuidValue($value);
+    }
+
+    public function testPreviousExceptionIsKept(): void
+    {
+        try {
+            new UuidValue('not-a-uuid');
+        } catch (InvalidArgumentException $e) {
+            $this->assertInstanceOf(InvalidArgumentException::class, $e->getPrevious());
+            return;
+        }
+
+        self::fail('The exception was not thrown.');
+    }
+}

--- a/tests/Db/Expression/Value/UuidValueTest.php
+++ b/tests/Db/Expression/Value/UuidValueTest.php
@@ -55,16 +55,4 @@ final class UuidValueTest extends TestCase
 
         new UuidValue($value);
     }
-
-    public function testPreviousExceptionIsKept(): void
-    {
-        try {
-            new UuidValue('not-a-uuid');
-        } catch (InvalidArgumentException $e) {
-            $this->assertInstanceOf(InvalidArgumentException::class, $e->getPrevious());
-            return;
-        }
-
-        self::fail('The exception was not thrown.');
-    }
 }

--- a/tests/Db/Helper/DbUuidHelperTest.php
+++ b/tests/Db/Helper/DbUuidHelperTest.php
@@ -49,7 +49,9 @@ final class DbUuidHelperTest extends TestCase
     public function testToUuidFailed($blobUuid, $expected): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Length of source data is should be 16 or 32 bytes.');
+        $this->expectExceptionMessage(
+            'Value is not a valid UUID. Expected the canonical form, 32 hexadecimal characters or 16 raw bytes.',
+        );
 
         $uuid = DbUuidHelper::toUuid($blobUuid);
         $this->assertEquals($expected, $uuid);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #1152

Adds `UuidValue`, an expression that carries a UUID and is bound in the representation the current DBMS expects — raw bytes for MySQL, MariaDB, SQLite and Oracle, canonical string for PostgreSQL and MSSQL:

```php
$db->createCommand()->insert('{{%page}}', ['id' => new UuidValue(Uuid::uuid7())])->execute();
```

It accepts the canonical form, 32 hexadecimal characters, 16 raw bytes or any `Stringable`. Passing raw bytes or a raw string directly keeps working as before.
